### PR TITLE
Ancestor samples

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -251,19 +251,83 @@ def subset_sites(ts, position):
                     metadata=mutation.metadata)
     return tables.tree_sequence()
 
+def minimise(ts):
+    tables = ts.dump_tables()
+
+    out_map = {}
+    in_map = {}
+    first_site = 0
+    for (_, edges_out, edges_in), tree in zip(ts.edge_diffs(), ts.trees()):
+        for edge in edges_out:
+            out_map[edge.child] = edge
+        for edge in edges_in:
+            in_map[edge.child] = edge
+        if tree.num_sites > 0:
+            sites = list(tree.sites())
+            if first_site:
+                x = 0
+                first_site = False
+            else:
+                x = sites[0].position
+            print("X = ", x)
+            for edge in out_map.values():
+                print("FLUSH", edge)
+            for edge in in_map.values():
+                print("INSER", edge)
+
+            # # Flush the edge buffer.
+            # for left, parent, child in edge_buffer:
+            #     tables.edges.add_row(left, x, parent, child)
+            # # Add edges for each node in the tree.
+            # edge_buffer.clear()
+            # for root in tree.roots:
+            #     for u in tree.nodes(root):
+            #         if u != root:
+            #             edge_buffer.append((x, tree.parent(u), u))
+
+    # position = np.hstack([[0], tables.sites.position, [ts.sequence_length]])
+    # position = tables.sites.position
+    # edges = []
+    # print(position)
+    # tables.edges.clear()
+    # for edge in ts.edges():
+    #     left = np.searchsorted(position, edge.left)
+    #     right = np.searchsorted(position, edge.right)
+
+    #     print(edge, left, right)
+    #     # if right - left > 1:
+    #         # print("KEEP:", edge, left, right)
+    #         # tables.edges.add_row(
+    #         #     position[left], position[right], edge.parent, edge.child)
+    #         # print("added", tables.edges[-1])
+    #     # else:
+    #         # print("SKIP:", edge, left, right)
+
+    # ts = tables.tree_sequence()
+    # for tree in ts.trees():
+    #     print("TREE:", tree.interval)
+    #     print(tree.draw(format="unicode"))
+
+
+
+
+
 def minimise_dev():
-    # ts = msprime.simulate(5, mutation_rate=1, recombination_rate=2, random_seed=3)
-    ts = msprime.load(sys.argv[1])
+    ts = msprime.simulate(5, mutation_rate=1, recombination_rate=2, random_seed=3)
+    # ts = msprime.load(sys.argv[1])
 
     position = ts.tables.sites.position[::2]
     subset_ts = subset_sites(ts, position)
     print("Got subset")
 
     ts_new = tsinfer.minimise(subset_ts)
+    for tree in ts_new.trees():
+        print("TREE:", tree.interval)
+        print(tree.draw(format="unicode"))
+    # print(ts_new.tables)
     print("done")
+    other = minimise(subset_ts)
 
-    # for tree in ts_new.trees():
-    #     print(tree.draw(format="unicode"))
 
 
 if __name__ == "__main__":

--- a/dev.py
+++ b/dev.py
@@ -126,27 +126,9 @@ def tsinfer_dev(
                 site.position, genotypes,
                 inference=np.sum(genotypes) > 1 and site.id % 2 == 0)
 
-    ts = tsinfer.infer(sample_data, simplify=False)
-    for tree in ts.trees():
-        print(tree.draw(format="unicode"))
-
-    # print("sample_data")
-    # print(sample_data)
-    # print(sample_data.samples_individual[:])
-    # # sample_data.close()
-
-
-    # with sample_data.copy() as other_data:
-    #     print("other_data = ")
-    #     print(other_data)
-    #     print("mode = ", other_data._mode)
-
-
-    # print("after")
-    # print(other_data)
-    # print("mode = ", other_data._mode)
-
-    # # print(sample_data)
+    # ts = tsinfer.infer(sample_data, simplify=False)
+    # for tree in ts.trees():
+    #     print(tree.draw(format="unicode"))
 
     # # sample_data.finalise()
     # # print(sample_data)
@@ -156,9 +138,11 @@ def tsinfer_dev(
     # print(sample_data)
 
     ancestor_data = tsinfer.generate_ancestors(sample_data, engine=engine)
-
     ancestors_ts = tsinfer.match_ancestors(sample_data, ancestor_data, engine=engine)
-    output_ts = tsinfer.match_samples(sample_data, ancestors_ts, engine=engine)
+
+    print(ancestors_ts.tables)
+
+    # output_ts = tsinfer.match_samples(sample_data, ancestors_ts, engine=engine)
     # dump_provenance(output_ts)
 
 
@@ -257,7 +241,7 @@ if __name__ == "__main__":
     # for j in range(1, 100):
     #     tsinfer_dev(15, 0.5, seed=j, num_threads=0, engine="P", recombination_rate=1e-8)
     # copy_1kg()
-    # tsinfer_dev(6, 0.3, seed=1, num_threads=0, engine="C", recombination_rate=1e-8)
+    tsinfer_dev(6, 0.3, seed=1, num_threads=0, engine="C", recombination_rate=1e-8)
 
 
 

--- a/dev.py
+++ b/dev.py
@@ -138,9 +138,11 @@ def tsinfer_dev(
     # print(sample_data)
 
     ancestor_data = tsinfer.generate_ancestors(sample_data, engine=engine)
+    for anc in ancestor_data.ancestors():
+        print(anc)
     ancestors_ts = tsinfer.match_ancestors(sample_data, ancestor_data, engine=engine)
 
-    print(ancestors_ts.tables)
+    # print(ancestors_ts.tables)
 
     # output_ts = tsinfer.match_samples(sample_data, ancestors_ts, engine=engine)
     # dump_provenance(output_ts)

--- a/dev.py
+++ b/dev.py
@@ -122,9 +122,15 @@ def tsinfer_dev(
         for j in range(ts.num_samples // 2):
             sample_data.add_individual(ploidy=2, metadata={"name": "ind_{}".format(j)})
         for site, genotypes in zip(ts.sites(), G):
-            sample_data.add_site(
-                site.position, genotypes,
-                inference=np.sum(genotypes) > 1 and site.id % 2 == 0)
+            sample_data.add_site(site.position, genotypes)
+    with tsinfer.SampleData(sequence_length=ts.sequence_length) as subset_samples:
+        for j in range(ts.num_samples // 2):
+            subset_samples.add_individual(ploidy=2, metadata={"name": "ind_{}".format(j)})
+        for site, genotypes in zip(ts.sites(), G):
+            if site.id % 2 == 0:
+                subset_samples.add_site(site.position, genotypes)
+    print(sample_data)
+    print(subset_samples)
 
     # ts = tsinfer.infer(sample_data, simplify=False)
     # for tree in ts.trees():
@@ -138,13 +144,9 @@ def tsinfer_dev(
     # print(sample_data)
 
     ancestor_data = tsinfer.generate_ancestors(sample_data, engine=engine)
-    for anc in ancestor_data.ancestors():
-        print(anc)
     ancestors_ts = tsinfer.match_ancestors(sample_data, ancestor_data, engine=engine)
-
-    # print(ancestors_ts.tables)
-
-    # output_ts = tsinfer.match_samples(sample_data, ancestors_ts, engine=engine)
+    # output_ts = tsinfer.match_samples(subset_samples, ancestors_ts, engine=engine)
+    output_ts = tsinfer.match_samples(sample_data, ancestors_ts, engine=engine)
     # dump_provenance(output_ts)
 
 
@@ -227,10 +229,55 @@ def tutorial_samples():
             progress.update()
     progress.close()
 
+def minimise_dev():
+    ts = msprime.simulate(5, mutation_rate=0, recombination_rate=2, random_seed=3)
+
+    ts_new = tsinfer.minimise(ts)
+
+    for tree in ts_new.trees():
+        print(tree.draw(format="unicode"))
+
+
+# TODO This name is a bit too generic and the implementation should be in msprime.
+def minimise(ts):
+    """
+    Returns a tree sequence with the minimal information required to represent
+    the tree topologies at its sites.
+    """
+    tables = ts.dump_tables()
+    tables.edges.clear()
+    edge_buffer = []
+    first_site = True
+    for tree in ts.trees():
+        if tree.num_sites > 0:
+            sites = list(tree.sites())
+            if first_site:
+                x = 0
+                first_site = False
+            else:
+                x = sites[0].position
+            # Flush the edge buffer.
+            for left, parent, child in edge_buffer:
+                tables.edges.add_row(left, x, parent, child)
+            # Add edges for each node in the tree.
+            edge_buffer.clear()
+            for root in tree.roots:
+                for u in tree.nodes(root):
+                    if u != root:
+                        edge_buffer.append((x, tree.parent(u), u))
+    # Flush the final edges.
+    for left, parent, child in edge_buffer:
+        tables.edges.add_row(left, tables.sequence_length, parent, child)
+    tables.sort()
+    tables.simplify(ts.samples())
+    record = provenance.get_provenance_dict(command="minimise")
+    tables.provenances.add_row(record=json.dumps(record))
+    return tables.tree_sequence()
+
 if __name__ == "__main__":
 
-    np.set_printoptions(linewidth=20000)
-    np.set_printoptions(threshold=20000000)
+    # np.set_printoptions(linewidth=20000)
+    # np.set_printoptions(threshold=20000000)
 
     # tutorial_samples()
 
@@ -243,9 +290,9 @@ if __name__ == "__main__":
     # for j in range(1, 100):
     #     tsinfer_dev(15, 0.5, seed=j, num_threads=0, engine="P", recombination_rate=1e-8)
     # copy_1kg()
-    tsinfer_dev(6, 0.3, seed=1, num_threads=0, engine="C", recombination_rate=1e-8)
+    # tsinfer_dev(6, 0.3, seed=4, num_threads=0, engine="C", recombination_rate=1e-8)
 
-
+    minimise_dev()
 
 #     for seed in range(1, 10000):
 #         print(seed)

--- a/dev.py
+++ b/dev.py
@@ -230,49 +230,13 @@ def tutorial_samples():
     progress.close()
 
 def minimise_dev():
-    ts = msprime.simulate(5, mutation_rate=0, recombination_rate=2, random_seed=3)
+    ts = msprime.simulate(5, mutation_rate=1, recombination_rate=2, random_seed=3)
 
     ts_new = tsinfer.minimise(ts)
 
     for tree in ts_new.trees():
         print(tree.draw(format="unicode"))
 
-
-# TODO This name is a bit too generic and the implementation should be in msprime.
-def minimise(ts):
-    """
-    Returns a tree sequence with the minimal information required to represent
-    the tree topologies at its sites.
-    """
-    tables = ts.dump_tables()
-    tables.edges.clear()
-    edge_buffer = []
-    first_site = True
-    for tree in ts.trees():
-        if tree.num_sites > 0:
-            sites = list(tree.sites())
-            if first_site:
-                x = 0
-                first_site = False
-            else:
-                x = sites[0].position
-            # Flush the edge buffer.
-            for left, parent, child in edge_buffer:
-                tables.edges.add_row(left, x, parent, child)
-            # Add edges for each node in the tree.
-            edge_buffer.clear()
-            for root in tree.roots:
-                for u in tree.nodes(root):
-                    if u != root:
-                        edge_buffer.append((x, tree.parent(u), u))
-    # Flush the final edges.
-    for left, parent, child in edge_buffer:
-        tables.edges.add_row(left, tables.sequence_length, parent, child)
-    tables.sort()
-    tables.simplify(ts.samples())
-    record = provenance.get_provenance_dict(command="minimise")
-    tables.provenances.add_row(record=json.dumps(record))
-    return tables.tree_sequence()
 
 if __name__ == "__main__":
 

--- a/requirements/conda-minimal.txt
+++ b/requirements/conda-minimal.txt
@@ -7,3 +7,4 @@ msprime
 zarr
 lmdb
 sortedcontainers
+attrs

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -10,6 +10,7 @@ daiquiri
 msprime
 zarr
 lmdb
+attrs
 # Only needed for the Python implementation.
 sortedcontainers
 # Optional extras for debugging threads

--- a/requirements/readthedocs.txt
+++ b/requirements/readthedocs.txt
@@ -1,3 +1,4 @@
+attrs
 six
 setuptools_scm 
 sphinx-argparse

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,8 @@ setup(
         "msprime>=0.6.0",
         "zarr>=2.2",
         "lmdb",
-        "sortedcontainers"
+        "sortedcontainers",
+        "attrs",
     ],
     ext_modules=[_tsinfer_module],
     keywords=[],

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -622,7 +622,8 @@ class TestAncestorData(unittest.TestCase, DataContainerMixin):
 
     def verify_data_round_trip(self, sample_data, ancestor_data, ancestors):
         for start, end, time, focal_sites, haplotype in ancestors:
-            ancestor_data.add_ancestor(start, end, time, focal_sites, haplotype)
+            ancestor_data.add_ancestor(
+                start, end, time, focal_sites, haplotype[start: end])
         ancestor_data.finalise()
 
         self.assertGreater(len(ancestor_data.uuid), 0)
@@ -638,7 +639,7 @@ class TestAncestorData(unittest.TestCase, DataContainerMixin):
         self.assertTrue(np.array_equal(
             inference_position, ancestor_data.sites_position[:]))
 
-        ancestors_list = list(ancestor_data.ancestors())
+        ancestors_list = [anc.haplotype for anc in ancestor_data.ancestors()]
         stored_start = ancestor_data.ancestors_start[:]
         stored_end = ancestor_data.ancestors_end[:]
         stored_time = ancestor_data.ancestors_time[:]
@@ -651,6 +652,12 @@ class TestAncestorData(unittest.TestCase, DataContainerMixin):
             self.assertTrue(np.array_equal(stored_focal_sites[j], focal_sites))
             self.assertTrue(np.array_equal(stored_ancestors[j], haplotype[start: end]))
             self.assertTrue(np.array_equal(ancestors_list[j], haplotype[start: end]))
+        for j, anc in enumerate(ancestor_data.ancestors()):
+            self.assertEqual(stored_start[j], anc.start)
+            self.assertEqual(stored_end[j], anc.end)
+            self.assertEqual(stored_time[j], anc.time)
+            self.assertTrue(np.array_equal(stored_focal_sites[j], anc.focal_sites))
+            self.assertTrue(np.array_equal(stored_ancestors[j], anc.haplotype))
 
     def test_defaults_no_path(self):
         sample_data, ancestors = self.get_example_data(10, 10, 40)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -453,9 +453,9 @@ class TestGeneratedAncestors(unittest.TestCase):
 
         A = np.zeros(
             (ancestor_data.num_sites, ancestor_data.num_ancestors), dtype=np.uint8)
-        start = ancestor_data.start[:]
-        end = ancestor_data.end[:]
-        ancestors = ancestor_data.ancestor[:]
+        start = ancestor_data.ancestors_start[:]
+        end = ancestor_data.ancestors_end[:]
+        ancestors = ancestor_data.ancestors_haplotype[:]
         for j in range(ancestor_data.num_ancestors):
             A[start[j]: end[j], j] = ancestors[j]
         for engine in [tsinfer.PY_ENGINE, tsinfer.C_ENGINE]:
@@ -504,13 +504,14 @@ class TestBuildAncestors(unittest.TestCase):
         return sample_data, ancestor_data
 
     def verify_ancestors(self, sample_data, ancestor_data):
-        ancestors = ancestor_data.ancestor[:]
+        ancestors = ancestor_data.ancestors_haplotype[:]
         inference_sites = sample_data.sites_inference[:]
+        position = sample_data.sites_position[:][inference_sites == 1]
         sample_genotypes = sample_data.sites_genotypes[:][inference_sites == 1, :]
-        start = ancestor_data.start[:]
-        end = ancestor_data.end[:]
-        time = ancestor_data.time[:]
-        focal_sites = ancestor_data.focal_sites[:]
+        start = ancestor_data.ancestors_start[:]
+        end = ancestor_data.ancestors_end[:]
+        time = ancestor_data.ancestors_time[:]
+        focal_sites = ancestor_data.ancestors_focal_sites[:]
 
         self.assertEqual(ancestor_data.num_ancestors, ancestors.shape[0])
         self.assertEqual(ancestor_data.num_sites, sample_data.num_inference_sites)
@@ -518,6 +519,7 @@ class TestBuildAncestors(unittest.TestCase):
         self.assertEqual(ancestor_data.num_ancestors, start.shape[0])
         self.assertEqual(ancestor_data.num_ancestors, end.shape[0])
         self.assertEqual(ancestor_data.num_ancestors, focal_sites.shape[0])
+        self.assertTrue(np.array_equal(ancestor_data.sites_position[:], position))
         # The first ancestor must be all zeros.
         self.assertEqual(start[0], 0)
         self.assertEqual(end[0], ancestor_data.num_sites)
@@ -559,8 +561,8 @@ class TestBuildAncestors(unittest.TestCase):
         sample_data, ancestor_data = self.get_simulated_example(ts)
         self.verify_ancestors(sample_data, ancestor_data)
         # Make sure we have at least one partial ancestor.
-        start = ancestor_data.start[:]
-        end = ancestor_data.end[:]
+        start = ancestor_data.ancestors_start[:]
+        end = ancestor_data.ancestors_end[:]
         self.assertLess(np.min(end - start), ancestor_data.num_sites)
 
     def test_random_data(self):

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -708,9 +708,11 @@ class TestPartialAncestorMatching(unittest.TestCase):
         ancestor_data.add_ancestor(  # ID 1
             start=0, end=6, focal_sites=[], time=4, haplotype=[0, 0, 0, 0, 0, 0])
         ancestor_data.add_ancestor(  # ID 2
-            start=0, end=3, focal_sites=[2], time=3, haplotype=[0, 0, 1, -1, -1, -1])
+            start=0, end=3, focal_sites=[2], time=3,
+            haplotype=[0, 0, 1, -1, -1, -1][0: 3])
         ancestor_data.add_ancestor(  # ID 3
-            start=3, end=6, focal_sites=[4], time=2, haplotype=[-1, -1, -1, 0, 1, 0])
+            start=3, end=6, focal_sites=[4], time=2,
+            haplotype=[-1, -1, -1, 0, 1, 0][3: 6])
         ancestor_data.add_ancestor(  # ID 4
             start=0, end=6, focal_sites=[0, 1, 3, 5], time=1,
             haplotype=[1, 1, 1, 1, 1, 1])
@@ -737,10 +739,11 @@ class TestPartialAncestorMatching(unittest.TestCase):
         ancestor_data.add_ancestor(  # ID 1
             start=0, end=7, focal_sites=[], time=4, haplotype=[0, 0, 0, 0, 0, 0, 0])
         ancestor_data.add_ancestor(  # ID 2
-            start=0, end=3, focal_sites=[2], time=3, haplotype=[0, 0, 1, 0, 0, 0, 0])
+            start=0, end=3, focal_sites=[2], time=3,
+            haplotype=[0, 0, 1, 0, 0, 0, 0][0: 3])
         ancestor_data.add_ancestor(  # ID 3
             start=3, end=7, focal_sites=[4, 6], time=2,
-            haplotype=[-1, -1, -1, 0, 1, 0, 1])
+            haplotype=[-1, -1, -1, 0, 1, 0, 1][3: 7])
         ancestor_data.add_ancestor(  # ID 4
             start=0, end=7, focal_sites=[0, 1, 3, 5], time=1,
             haplotype=[1, 1, 1, 1, 1, 1, 1])
@@ -769,19 +772,19 @@ class TestPartialAncestorMatching(unittest.TestCase):
             haplotype=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         ancestor_data.add_ancestor(  # ID 2
             start=0, end=4, focal_sites=[], time=6,
-            haplotype=[0, 0, 0, 0, -1, -1, -1, -1, -1, -1, -1, -1])
+            haplotype=[0, 0, 0, 0, -1, -1, -1, -1, -1, -1, -1, -1][0: 4])
         ancestor_data.add_ancestor(  # ID 3
             start=4, end=12, focal_sites=[], time=5,
-            haplotype=[-1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0])
+            haplotype=[-1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0][4: 12])
         ancestor_data.add_ancestor(  # ID 4
             start=8, end=12, focal_sites=[9, 11], time=4,
-            haplotype=[-1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 0, 1])
+            haplotype=[-1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 0, 1][8: 12])
         ancestor_data.add_ancestor(  # ID 5
             start=4, end=8, focal_sites=[5, 7], time=3,
-            haplotype=[-1, -1, -1, -1, 0, 1, 0, 1, -1, -1, -1, -1])
+            haplotype=[-1, -1, -1, -1, 0, 1, 0, 1, -1, -1, -1, -1][4: 8])
         ancestor_data.add_ancestor(  # ID 6
             start=0, end=4, focal_sites=[1, 3], time=2,
-            haplotype=[0, 1, 0, 1, -1, -1, -1, -1, -1, -1, -1, -1])
+            haplotype=[0, 1, 0, 1, -1, -1, -1, -1, -1, -1, -1, -1][0: 4])
         ancestor_data.add_ancestor(  # ID 7
             start=0, end=12, focal_sites=[0, 2, 4, 6, 8, 10], time=1,
             haplotype=[1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0])

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -969,6 +969,8 @@ def squash_edges(ts):
     t = ts.tables.nodes.time
     edges = list(ts.edges())
     edges.sort(key=lambda e: (t[e.parent], e.parent, e.child, e.left))
+    if len(edges) == 0:
+        return []
 
     squashed = []
     last_e = edges[0]
@@ -1015,7 +1017,7 @@ class TestMinimise(unittest.TestCase):
         self.assertTrue(np.array_equal(ts.genotype_matrix(), mts.genotype_matrix()))
 
         edges = list(mts.edges())
-        squashed = squash_edges(ts)
+        squashed = squash_edges(mts)
         self.assertEqual(len(edges), len(squashed))
         self.assertEqual(edges, squashed)
 

--- a/tsinfer/evaluation.py
+++ b/tsinfer/evaluation.py
@@ -381,7 +381,7 @@ def build_simulated_ancestors(sample_data, ancestor_data, ts, time_chunking=Fals
         assert all(s <= site < e for site in focal)
         ancestor_data.add_ancestor(
             start=s, end=e, time=t, focal_sites=np.array(focal, dtype=np.int32),
-            haplotype=a)
+            haplotype=a[s:e])
 
 
 def print_tree_pairs(ts1, ts2, compute_distances=True):

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -1119,6 +1119,9 @@ class SampleData(DataContainer):
             elif self._build_state == self.ADDING_SITES:
                 self._sites_writer.flush()
             self._build_state = -1
+            if self.sequence_length == 0:
+                self.data.attrs["sequence_length"] = self._last_position + 1
+
         super(SampleData, self).finalise(**kwargs)
 
     ####################################
@@ -1193,7 +1196,7 @@ class AncestorData(DataContainer):
         compression level and algorithm performance. Default=1024.
     """
     FORMAT_NAME = "tsinfer-ancestor-data"
-    FORMAT_VERSION = (0, 2)
+    FORMAT_VERSION = (1, 0)
 
     def __init__(self, sample_data, **kwargs):
         super().__init__(**kwargs)
@@ -1201,28 +1204,38 @@ class AncestorData(DataContainer):
         # Cache the num_sites value here as it's expensive to compute.
         self._num_sites = self.sample_data.num_inference_sites
         self.data.attrs["sample_data_uuid"] = sample_data.uuid
-        self.data.attrs["num_sites"] = self.sample_data.num_inference_sites
+        self.data.attrs["sequence_length"] = self.sample_data.sequence_length
 
         chunks = self._chunk_size
+        # Add in the positions for the sites.
+        sites_inference = self.sample_data.sites_inference[:]
+        position = self.sample_data.sites_position[:][sites_inference == 1]
         self.data.create_dataset(
-            "start", shape=(0,), chunks=chunks, compressor=self._compressor,
+            "sites/position", data=position, chunks=chunks, compressor=self._compressor,
+            dtype=np.float64)
+
+        self.data.create_dataset(
+            "ancestors/start", shape=(0,), chunks=chunks, compressor=self._compressor,
             dtype=np.int32)
         self.data.create_dataset(
-            "end", shape=(0,), chunks=chunks, compressor=self._compressor,
+            "ancestors/end", shape=(0,), chunks=chunks, compressor=self._compressor,
             dtype=np.int32)
         self.data.create_dataset(
-            "time", shape=(0,), chunks=chunks, compressor=self._compressor,
+            "ancestors/time", shape=(0,), chunks=chunks, compressor=self._compressor,
             dtype=np.uint32)
         self.data.create_dataset(
-            "focal_sites", shape=(0,), chunks=chunks,
+            "ancestors/focal_sites", shape=(0,), chunks=chunks,
             dtype="array:i4", compressor=self._compressor)
         self.data.create_dataset(
-            "ancestor", shape=(0,), chunks=chunks,
+            "ancestors/haplotype", shape=(0,), chunks=chunks,
             dtype="array:u1", compressor=self._compressor)
 
         self.item_writer = BufferedItemWriter({
-            "start": self.start, "end": self.end, "time": self.time,
-            "focal_sites": self.focal_sites, "ancestor": self.ancestor},
+            "start": self.ancestors_start,
+            "end": self.ancestors_end,
+            "time": self.ancestors_time,
+            "focal_sites": self.ancestors_focal_sites,
+            "haplotype": self.ancestors_haplotype},
             num_threads=self._num_flush_threads)
 
     def summary(self):
@@ -1231,14 +1244,16 @@ class AncestorData(DataContainer):
 
     def __str__(self):
         values = [
+            ("sequence_length", self.sequence_length),
             ("sample_data_uuid", self.sample_data_uuid),
             ("num_ancestors", self.num_ancestors),
             ("num_sites", self.num_sites),
-            ("start", zarr_summary(self.start)),
-            ("end", zarr_summary(self.end)),
-            ("time", zarr_summary(self.time)),
-            ("focal_sites", zarr_summary(self.focal_sites)),
-            ("ancestor", zarr_summary(self.ancestor))]
+            ("sites/position", zarr_summary(self.sites_position)),
+            ("ancestors/start", zarr_summary(self.ancestors_start)),
+            ("ancestors/end", zarr_summary(self.ancestors_end)),
+            ("ancestors/time", zarr_summary(self.ancestors_time)),
+            ("ancestors/focal_sites", zarr_summary(self.ancestors_focal_sites)),
+            ("ancestors/haplotype", zarr_summary(self.ancestors_haplotype))]
         return super(AncestorData, self).__str__() + self._format_str(values)
 
     def data_equal(self, other):
@@ -1248,18 +1263,24 @@ class AncestorData(DataContainer):
         the UUID.
         """
         return (
+            self.sequence_length == other.sequence_length and
             self.sample_data_uuid == other.sample_data_uuid and
             self.format_name == other.format_name and
             self.format_version == other.format_version and
             self.num_ancestors == other.num_ancestors and
             self.num_sites == other.num_sites and
-            np.array_equal(self.start[:], other.start[:]) and
-            np.array_equal(self.end[:], other.end[:]) and
+            np.array_equal(self.sites_position[:], other.sites_position[:]) and
+            np.array_equal(self.ancestors_start[:], other.ancestors_start[:]) and
+            np.array_equal(self.ancestors_end[:], other.ancestors_end[:]) and
             # Need to take a different approach with np object arrays.
             all(itertools.starmap(np.array_equal, zip(
-                self.focal_sites[:], other.focal_sites[:]))) and
+                self.ancestors_focal_sites[:], other.ancestors_focal_sites[:]))) and
             all(itertools.starmap(np.array_equal, zip(
-                self.ancestor[:], other.ancestor[:]))))
+                self.ancestors_haplotype[:], other.ancestors_haplotype[:]))))
+
+    @property
+    def sequence_length(self):
+        return self.data.attrs["sequence_length"]
 
     @property
     def sample_data_uuid(self):
@@ -1267,31 +1288,35 @@ class AncestorData(DataContainer):
 
     @property
     def num_ancestors(self):
-        return self.start.shape[0]
+        return self.ancestors_start.shape[0]
 
     @property
     def num_sites(self):
-        return self.data.attrs["num_sites"]
+        return self.sites_position.shape[0]
 
     @property
-    def start(self):
-        return self.data["start"]
+    def sites_position(self):
+        return self.data["sites/position"]
 
     @property
-    def end(self):
-        return self.data["end"]
+    def ancestors_start(self):
+        return self.data["ancestors/start"]
 
     @property
-    def time(self):
-        return self.data["time"]
+    def ancestors_end(self):
+        return self.data["ancestors/end"]
 
     @property
-    def focal_sites(self):
-        return self.data["focal_sites"]
+    def ancestors_time(self):
+        return self.data["ancestors/time"]
 
     @property
-    def ancestor(self):
-        return self.data["ancestor"]
+    def ancestors_focal_sites(self):
+        return self.data["ancestors/focal_sites"]
+
+    @property
+    def ancestors_haplotype(self):
+        return self.data["ancestors/haplotype"]
 
     ####################################
     # Write mode
@@ -1304,8 +1329,8 @@ class AncestorData(DataContainer):
         and has new mutations at the specified list of focal sites.
         """
         self._check_build_mode()
-        haplotype = np.array(haplotype, dtype=np.uint8, copy=False)
-        focal_sites = np.array(focal_sites, dtype=np.int32, copy=False)
+        haplotype = np.array(haplotype, dtype=np.uint8)
+        focal_sites = np.array(focal_sites, dtype=np.int32)
         if start < 0:
             raise ValueError("Start must be >= 0")
         if end > self._num_sites:
@@ -1322,10 +1347,9 @@ class AncestorData(DataContainer):
             raise ValueError("focal sites must be between start and end")
         if np.any(haplotype[start: end] > 1):
             raise ValueError("Biallelic sites only supported.")
-        ancestor = haplotype[start:end].copy()
         self.item_writer.add(
             start=start, end=end, time=time, focal_sites=focal_sites,
-            ancestor=ancestor)
+            haplotype=haplotype[start:end])
 
     def finalise(self, **kwargs):
         if self._mode == self.BUILD_MODE:
@@ -1338,7 +1362,8 @@ class AncestorData(DataContainer):
         """
         Returns an iterator over all the ancestors.
         """
-        for a in chunk_iterator(self.ancestor):
+        # TODO this should return objects with the values decoded.
+        for a in chunk_iterator(self.ancestors_haplotype):
             yield a
 
 

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -1219,6 +1219,8 @@ class AncestorData(DataContainer):
         # Cache the num_sites value here as it's expensive to compute.
         self._num_sites = self.sample_data.num_inference_sites
         self.data.attrs["sample_data_uuid"] = sample_data.uuid
+        if self.sample_data.sequence_length == 0:
+            raise ValueError("Bad samples file: sequence_length cannot be zero")
         self.data.attrs["sequence_length"] = self.sample_data.sequence_length
 
         chunks = self._chunk_size

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -574,10 +574,10 @@ class AncestorMatcher(Matcher):
         super().__init__(sample_data, **kwargs)
         self.ancestor_data = ancestor_data
         self.num_ancestors = self.ancestor_data.num_ancestors
-        self.epoch = self.ancestor_data.time[:]
-        self.focal_sites = self.ancestor_data.focal_sites[:]
-        self.start = self.ancestor_data.start[:]
-        self.end = self.ancestor_data.end[:]
+        self.epoch = self.ancestor_data.ancestors_time[:]
+        self.focal_sites = self.ancestor_data.ancestors_focal_sites[:]
+        self.start = self.ancestor_data.ancestors_start[:]
+        self.end = self.ancestor_data.ancestors_end[:]
 
         # Create a list of all ID ranges in each epoch.
         if self.start.shape[0] == 0:

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -938,7 +938,23 @@ def minimise(ts):
     the tree topologies at its sites.
     """
     tables = ts.dump_tables()
+    edge_map = {}
+
+    def add_edge(left, right, parent, child):
+        new_edge = msprime.Edge(left, right, parent, child)
+        if child not in edge_map:
+            edge_map[child] = new_edge
+        else:
+            edge = edge_map[child]
+            if edge.right == left and edge.parent == parent:
+                # Squash
+                edge.right = right
+            else:
+                tables.edges.add_row(edge.left, edge.right, edge.parent, edge.child)
+                edge_map[child] = new_edge
+
     tables.edges.clear()
+
     edge_buffer = []
     first_site = True
     for tree in ts.trees():
@@ -951,16 +967,20 @@ def minimise(ts):
                 x = sites[0].position
             # Flush the edge buffer.
             for left, parent, child in edge_buffer:
-                tables.edges.add_row(left, x, parent, child)
+                add_edge(left, x, parent, child)
             # Add edges for each node in the tree.
             edge_buffer.clear()
             for root in tree.roots:
                 for u in tree.nodes(root):
                     if u != root:
                         edge_buffer.append((x, tree.parent(u), u))
-    # Flush the final edges.
+    # Add the final edges.
     for left, parent, child in edge_buffer:
-        tables.edges.add_row(left, tables.sequence_length, parent, child)
+        add_edge(left, tables.sequence_length, parent, child)
+    # Flush the remaining edges to the table
+    for edge in edge_map.values():
+        tables.edges.add_row(edge.left, edge.right, edge.parent, edge.child)
+
     tables.sort()
     record = provenance.get_provenance_dict(command="minimise")
     tables.provenances.add_row(record=json.dumps(record))

--- a/update_seq_len.py
+++ b/update_seq_len.py
@@ -1,0 +1,26 @@
+"""
+Quick script to patch up the sequence length attribute in version
+1.0 sample files to make sure they are not 0. Older version supported
+this but new versions will not.
+"""
+
+import tsinfer
+import zarr
+import sys
+import os.path
+
+filename = sys.argv[1]
+sample_data = tsinfer.load(filename)
+sequence_length = sample_data.sites_position[-1] + 1
+sample_data.close()
+
+# Add a megabyte to the map size in the file size goes up.
+map_size = os.path.getsize(filename) + 1024**2
+store = zarr.LMDBStore(filename, subdir=False, map_size=map_size)
+data = zarr.open(store=store, mode="w+")
+data.attrs["sequence_length"] = sequence_length
+store.close()
+
+sample_data = tsinfer.load(filename)
+print("patched up sequence length")
+print(sample_data)


### PR DESCRIPTION
There is a number of breaking changes here:

1. The AncestorData file format version is bumped to version 1.0. Older versions won't be readable. The API and structure has changed slightly --- use ``python -m tsinfer <ancestors file>`` to see the new structure.
2. Older ancestors tree sequences won't work either, as the way they are stored has been updated. All these must be regenerated.
3. Any version 1.0 samples files with sequence_length of 0 won't be accepted as valid input any more. These can be patched up automatically with the ``update_seq_len.py`` script that's included here.