### PR TITLE
Fix path compression

### DIFF
--- a/_tsinfermodule.c
+++ b/_tsinfermodule.c
@@ -449,20 +449,21 @@ TreeSequenceBuilder_add_node(TreeSequenceBuilder *self, PyObject *args, PyObject
     int err;
     PyObject *ret = NULL;
 
-    static char *kwlist[] = {"time", NULL};
+    static char *kwlist[] = {"time", "is_sample", "is_synthetic", NULL};
     double time;
     int is_sample = true;
+    int is_synthetic = false;
 
     if (TreeSequenceBuilder_check_state(self) != 0) {
         goto out;
     }
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "d|i", kwlist, &time,
-                &is_sample)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "d|ii", kwlist, &time,
+                &is_sample, &is_synthetic)) {
         goto out;
     }
 
     err = tree_sequence_builder_add_node(self->tree_sequence_builder,
-            time, is_sample);
+            time, is_sample, is_synthetic);
     if (err < 0) {
         handle_library_error(err);
         goto out;

--- a/dev.py
+++ b/dev.py
@@ -118,8 +118,25 @@ def tsinfer_dev(
 
     ancestor_data = tsinfer.generate_ancestors(
         sample_data, engine=engine, num_threads=num_threads)
-    print(ancestor_data)
-#     ancestors_ts = tsinfer.match_ancestors(sample_data, ancestor_data, engine=engine)
+    ancestors_ts = tsinfer.match_ancestors(
+        sample_data, ancestor_data, engine=engine, path_compression=True)
+
+    ts = tsinfer.match_samples(sample_data, ancestors_ts,
+            path_compression=False, simplify=False, engine=engine)
+
+    for node in ts.nodes():
+        if node.flags == 0:
+            print("Synthetic node", node.id, node.time)
+            parent_edges = [edge for edge in ts.edges() if edge.parent == node.id]
+            child_edges = [edge for edge in ts.edges() if edge.child == node.id]
+            child_edges.sort(key=lambda e: e.left)
+            print("parent edges")
+            for edge in parent_edges:
+                print("\t", edge)
+            print("child edges")
+            for edge in child_edges:
+                print("\t", edge)
+
 #     # output_ts = tsinfer.match_samples(subset_samples, ancestors_ts, engine=engine)
 #     output_ts = tsinfer.match_samples(sample_data, ancestors_ts, engine=engine)
 #     # dump_provenance(output_ts)
@@ -328,7 +345,7 @@ if __name__ == "__main__":
     # for j in range(1, 100):
     #     tsinfer_dev(15, 0.5, seed=j, num_threads=0, engine="P", recombination_rate=1e-8)
     # copy_1kg()
-    tsinfer_dev(36, 0.3, seed=4, num_threads=0, engine="P", recombination_rate=1e-8)
+    tsinfer_dev(10, 0.025, seed=4, num_threads=0, engine="P", recombination_rate=1e-8)
 
     # minimise_dev()
 

--- a/dev.py
+++ b/dev.py
@@ -119,13 +119,15 @@ def tsinfer_dev(
     ancestor_data = tsinfer.generate_ancestors(
         sample_data, engine=engine, num_threads=num_threads)
     ancestors_ts = tsinfer.match_ancestors(
-        sample_data, ancestor_data, engine=engine, path_compression=True)
+        sample_data, ancestor_data, engine=engine, path_compression=True,
+        extended_checks=True)
 
     ts = tsinfer.match_samples(sample_data, ancestors_ts,
-            path_compression=False, simplify=False, engine=engine)
+            path_compression=True, simplify=False, engine=engine,
+            extended_checks=True)
 
     for node in ts.nodes():
-        if node.flags == 0:
+        if tsinfer.is_synthetic(node.flags):
             print("Synthetic node", node.id, node.time)
             parent_edges = [edge for edge in ts.edges() if edge.parent == node.id]
             child_edges = [edge for edge in ts.edges() if edge.child == node.id]
@@ -345,7 +347,7 @@ if __name__ == "__main__":
     # for j in range(1, 100):
     #     tsinfer_dev(15, 0.5, seed=j, num_threads=0, engine="P", recombination_rate=1e-8)
     # copy_1kg()
-    tsinfer_dev(10, 0.025, seed=4, num_threads=0, engine="P", recombination_rate=1e-8)
+    tsinfer_dev(20, 0.25, seed=4, num_threads=0, engine="C", recombination_rate=1e-8)
 
     # minimise_dev()
 

--- a/lib/main.c
+++ b/lib/main.c
@@ -339,12 +339,12 @@ run_generate(const char *input_file, int verbose, int path_compression)
     }
 
     /* Add the ultimate ancestor */
-    ret = tree_sequence_builder_add_node(&ts_builder, num_samples + 1, true);
+    ret = tree_sequence_builder_add_node(&ts_builder, num_samples + 1, true, false);
     if (ret < 0) {
         fatal_error("add node");
     }
     /* Add the root ancestor */
-    ret = tree_sequence_builder_add_node(&ts_builder, num_samples, true);
+    ret = tree_sequence_builder_add_node(&ts_builder, num_samples, true, false);
     if (ret < 0) {
         fatal_error("add node");
     }
@@ -352,7 +352,7 @@ run_generate(const char *input_file, int verbose, int path_compression)
     for (frequency = num_samples - 1; frequency > 0; frequency--) {
         num_ancestors =  avl_count(&ancestor_builder.frequency_map[frequency]);
         for (j = 0; j < num_ancestors; j++) {
-            ret = tree_sequence_builder_add_node(&ts_builder, frequency, true);
+            ret = tree_sequence_builder_add_node(&ts_builder, frequency, true, false);
             if (ret < 0) {
                 fatal_error("add node");
             }
@@ -527,7 +527,7 @@ run_generate(const char *input_file, int verbose, int path_compression)
 
 
     for (j = 0; j < num_samples; j++) {
-        ret = tree_sequence_builder_add_node(&ts_builder, 0, true);
+        ret = tree_sequence_builder_add_node(&ts_builder, 0, true, false);
         if (ret < 0) {
             fatal_error("add node");
         }

--- a/lib/tree_sequence_builder.c
+++ b/lib/tree_sequence_builder.c
@@ -524,28 +524,6 @@ typedef struct {
     indexed_edge_t *dest;
 } edge_map_t;
 
-typedef struct {
-    node_id_t node;
-    uint32_t count;
-} node_counter_t;
-
-
-/* Remap the edges in the set of matches to point to the already existing
- * synthethic node. */
-static int
-tree_sequence_builder_remap_synthetic(tree_sequence_builder_t *self,
-        node_id_t mapped_child, int num_mapped, edge_map_t *mapped)
-{
-    int ret = 0;
-    int j;
-
-    for (j = 0; j < num_mapped; j++) {
-        if (mapped[j].dest->edge.child == mapped_child) {
-            mapped[j].source->edge.parent = mapped_child;
-        }
-    }
-    return ret;
-}
 
 static void
 tree_sequence_builder_squash_edges(tree_sequence_builder_t *self, node_id_t node)
@@ -626,7 +604,7 @@ out:
  * segments of existing ancestors. */
 static int
 tree_sequence_builder_make_synthetic_node(tree_sequence_builder_t *self,
-        node_id_t mapped_child, int num_mapped, edge_map_t *mapped)
+        edge_map_t *mapped, size_t num_mapped)
 {
     int ret = 0;
     node_id_t synthetic_node;
@@ -634,14 +612,14 @@ tree_sequence_builder_make_synthetic_node(tree_sequence_builder_t *self,
     indexed_edge_t *head = NULL;
     indexed_edge_t *prev = NULL;
     double min_parent_time;
-    int j;
+    node_id_t mapped_child = mapped[0].dest->edge.child;
+    size_t j;
 
     min_parent_time = self->time[0] + 1;
     for (j = 0; j < num_mapped; j++) {
-        if (mapped[j].dest->edge.child == mapped_child) {
-            min_parent_time = TSI_MIN(
-                min_parent_time, self->time[mapped[j].source->edge.parent]);
-        }
+        assert(mapped[j].dest->edge.child == mapped_child);
+        min_parent_time = TSI_MIN(
+            min_parent_time, self->time[mapped[j].source->edge.parent]);
     }
     ret = tree_sequence_builder_add_node(self, min_parent_time - 0.5, false, true);
     if (ret < 0) {
@@ -650,33 +628,31 @@ tree_sequence_builder_make_synthetic_node(tree_sequence_builder_t *self,
     synthetic_node = ret;
 
     for (j = 0; j < num_mapped; j++) {
-        if (mapped[j].dest->edge.child == mapped_child) {
-            edge = tree_sequence_builder_alloc_edge(self,
-                    mapped[j].source->edge.left,
-                    mapped[j].source->edge.right,
-                    mapped[j].source->edge.parent,
-                    synthetic_node, NULL);
-            if (edge == NULL) {
-                ret = TSI_ERR_NO_MEMORY;
-                goto out;
-            }
-            if (head == NULL) {
-                head = edge;
-            } else {
-                prev->next = edge;
-            }
-            prev = edge;
-            mapped[j].source->edge.parent = synthetic_node;
-            /* We are modifying the existing edge, so we must remove it
-             * from the indexes. Mark that it is unindexed by setting the
-             * child value to NULL_NODE. */
-            ret = tree_sequence_builder_unindex_edge(self, mapped[j].dest);
-            if (ret != 0) {
-                goto out;
-            }
-            mapped[j].dest->edge.parent = synthetic_node;
-            mapped[j].dest->edge.child = NULL_NODE;
+        edge = tree_sequence_builder_alloc_edge(self,
+                mapped[j].source->edge.left,
+                mapped[j].source->edge.right,
+                mapped[j].source->edge.parent,
+                synthetic_node, NULL);
+        if (edge == NULL) {
+            ret = TSI_ERR_NO_MEMORY;
+            goto out;
         }
+        if (head == NULL) {
+            head = edge;
+        } else {
+            prev->next = edge;
+        }
+        prev = edge;
+        mapped[j].source->edge.parent = synthetic_node;
+        /* We are modifying the existing edge, so we must remove it
+         * from the indexes. Mark that it is unindexed by setting the
+         * child value to NULL_NODE. */
+        ret = tree_sequence_builder_unindex_edge(self, mapped[j].dest);
+        if (ret != 0) {
+            goto out;
+        }
+        mapped[j].dest->edge.parent = synthetic_node;
+        mapped[j].dest->edge.child = NULL_NODE;
     }
     self->path[synthetic_node] = head;
     tree_sequence_builder_squash_edges(self, synthetic_node);
@@ -697,23 +673,26 @@ tree_sequence_builder_compress_path(tree_sequence_builder_t *self, node_id_t chi
 {
     int ret = 0;
     indexed_edge_t *c_edge, *match_edge;
+    edge_t last_match;
     edge_map_t *mapped = NULL;
-    node_counter_t *child_count = NULL;
+    size_t *contig_offsets = NULL;
     size_t path_length = 0;
-    int num_mapped = 0;
-    int num_mapped_children = 0;
-    int j, k;
+    size_t num_contigs = 0;
+    size_t num_mapped = 0;
+    size_t j, k, contig_size;
     node_id_t mapped_child;
 
     for (c_edge = self->path[child]; c_edge != NULL; c_edge = c_edge->next) {
         path_length++;
     }
     mapped = malloc(path_length * sizeof(*mapped));
-    child_count = calloc(path_length, sizeof(*child_count));
-    if (mapped == NULL || child_count == NULL) {
+    contig_offsets = malloc((path_length + 1)  * sizeof(*contig_offsets));
+    if (mapped == NULL || contig_offsets == NULL) {
         ret = TSI_ERR_NO_MEMORY;
         goto out;
     }
+    last_match.right = -1;
+    last_match.child = NULL_NODE;
 
     for (c_edge = self->path[child]; c_edge != NULL; c_edge = c_edge->next) {
         /* Can we find a match for this edge? */
@@ -721,43 +700,40 @@ tree_sequence_builder_compress_path(tree_sequence_builder_t *self, node_id_t chi
         if (match_edge != NULL) {
             mapped[num_mapped].source = c_edge;
             mapped[num_mapped].dest = match_edge;
+            if (!(c_edge->edge.left == last_match.right &&
+                    match_edge->edge.child == last_match.child)) {
+                contig_offsets[num_contigs] = num_mapped;
+                num_contigs++;
+            }
+            last_match = match_edge->edge;
             num_mapped++;
         }
     }
-    for (j = 0; j < num_mapped; j++) {
-        mapped_child = mapped[j].dest->edge.child;
-        /* Increment the counter for this child. */
-        for (k = 0; k < num_mapped_children; k++) {
-            if (child_count[k].node == mapped_child) {
-                break;
-            }
-        }
-        if (k == num_mapped_children) {
-            num_mapped_children++;
-        }
-        child_count[k].node = mapped_child;
-        child_count[k].count++;
-    }
+    contig_offsets[num_contigs] = num_mapped;
 
-    for (k = 0; k < num_mapped_children; k++) {
-        if (child_count[k].count > 1) {
-            mapped_child = child_count[k].node;
-            if (self->node_flags[mapped_child] == 0) {
-                ret = tree_sequence_builder_remap_synthetic(self, mapped_child,
-                        num_mapped, mapped);
+    for (j = 0; j < num_contigs; j++) {
+        contig_size = contig_offsets[j + 1] - contig_offsets[j];
+        if (contig_size > 1) {
+            mapped_child = mapped[contig_offsets[j]].dest->edge.child;
+            if ((self->node_flags[mapped_child] & TSI_NODE_SYNTHETIC) != 0) {
+                /* Remap the edges in the set of matches to point to the already
+                 * existing synthethic node. */
+                for (k = contig_offsets[j]; k < contig_offsets[j + 1]; k++) {
+                    mapped[k].source->edge.parent = mapped_child;
+                }
             } else {
-                ret = tree_sequence_builder_make_synthetic_node(self, mapped_child,
-                        num_mapped, mapped);
-            }
-            if (ret != 0) {
-                goto out;
+                ret = tree_sequence_builder_make_synthetic_node(self,
+                        mapped + contig_offsets[j], contig_size);
+                if (ret != 0) {
+                    goto out;
+                }
             }
         }
     }
     tree_sequence_builder_squash_edges(self, child);
 out:
     tsi_safe_free(mapped);
-    tsi_safe_free(child_count);
+    tsi_safe_free(contig_offsets);
     return ret;
 }
 

--- a/lib/tsinfer.h
+++ b/lib/tsinfer.h
@@ -42,6 +42,8 @@
 #define TSI_COMPRESS_PATH   1
 #define TSI_EXTENDED_CHECKS 2
 
+#define TSI_NODE_SYNTHETIC ((uint32_t) (1u << 16))
+
 /* TODO change all instances of this to node_id_t */
 typedef int32_t ancestor_id_t;
 typedef int32_t node_id_t;
@@ -223,7 +225,7 @@ int tree_sequence_builder_alloc(tree_sequence_builder_t *self,
 int tree_sequence_builder_print_state(tree_sequence_builder_t *self, FILE *out);
 int tree_sequence_builder_free(tree_sequence_builder_t *self);
 int tree_sequence_builder_add_node(tree_sequence_builder_t *self,
-        double time, bool is_sample);
+        double time, bool is_sample, bool is_synthetic);
 int tree_sequence_builder_add_path(tree_sequence_builder_t *self,
         node_id_t child, size_t num_edges, site_id_t *left, site_id_t *right,
         node_id_t *parent, int flags);

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -29,7 +29,6 @@ import numpy as np
 import msprime
 
 import tsinfer
-import tsinfer.formats as formats
 
 
 def get_random_data_example(num_samples, num_sites, seed=42):
@@ -59,7 +58,7 @@ class TestRoundTrip(unittest.TestCase):
     def verify_data_round_trip(self, genotypes, positions, sequence_length=None):
         if sequence_length is None:
             sequence_length = positions[-1] + 1
-        sample_data = formats.SampleData(sequence_length=sequence_length)
+        sample_data = tsinfer.SampleData(sequence_length=sequence_length)
         for j in range(genotypes.shape[0]):
             sample_data.add_site(positions[j], genotypes[j])
         sample_data.finalise()
@@ -389,7 +388,7 @@ class TestThreads(TsinferTestCase):
     def test_equivalance(self):
         rho = 2
         ts = msprime.simulate(5, mutation_rate=2, recombination_rate=rho, random_seed=2)
-        sample_data = formats.SampleData.from_tree_sequence(ts)
+        sample_data = tsinfer.SampleData.from_tree_sequence(ts)
         ts1 = tsinfer.infer(sample_data, num_threads=1)
         ts2 = tsinfer.infer(sample_data, num_threads=5)
         self.assertTreeSequencesEqual(ts1, ts2)
@@ -493,11 +492,11 @@ class TestGeneratedAncestors(unittest.TestCase):
         # Verifies that we can round-trip the specified tree sequence
         # using the generated ancestors. NOTE: this must be an SMC
         # consistent tree sequence!
-        with formats.SampleData(sequence_length=ts.sequence_length) as sample_data:
+        with tsinfer.SampleData(sequence_length=ts.sequence_length) as sample_data:
             for v in ts.variants():
                 sample_data.add_site(v.position, v.genotypes, v.alleles)
 
-        ancestor_data = formats.AncestorData(sample_data)
+        ancestor_data = tsinfer.AncestorData(sample_data)
         tsinfer.build_simulated_ancestors(sample_data, ancestor_data, ts)
         ancestor_data.finalise()
 
@@ -693,22 +692,25 @@ class AlgorithmsExactlyEqualMixin(object):
         self.assertEqual(ts.num_sites, tsp.num_sites)
         self.assertEqual(ts.num_sites, tsc.num_sites)
         self.assertEqual(tsc.num_samples, tsp.num_samples)
-        if self.path_compression_enabled:
-            # With path compression we have to check the tree metrics.
-            p_breakpoints, distance = tsinfer.compare(ts, tsp)
-            self.assertTrue(np.all(distance == 0))
-            c_breakpoints, distance = tsinfer.compare(ts, tsc)
-            self.assertTrue(np.all(distance == 0))
-            self.assertTrue(np.all(p_breakpoints == c_breakpoints))
-        else:
-            # Without path compression we're guaranteed to return precisely the
-            # same tree sequences.
-            tables_p = tsp.dump_tables()
-            tables_c = tsc.dump_tables()
-            self.assertEqual(tables_p.nodes, tables_c.nodes)
-            self.assertEqual(tables_p.edges, tables_c.edges)
-            self.assertEqual(tables_p.sites, tables_c.sites)
-            self.assertEqual(tables_p.mutations, tables_c.mutations)
+        # if self.path_compression_enabled:
+        #     # With path compression we have to check the tree metrics.
+        #     p_breakpoints, distance = tsinfer.compare(ts, tsp)
+        #     self.assertTrue(np.all(distance == 0))
+        #     c_breakpoints, distance = tsinfer.compare(ts, tsc)
+        #     self.assertTrue(np.all(distance == 0))
+        #     self.assertTrue(np.all(p_breakpoints == c_breakpoints))
+        # else:
+        # Without path compression we're guaranteed to return precisely the
+        # same tree sequences.
+        tables_p = tsp.dump_tables()
+        tables_c = tsc.dump_tables()
+        print("FIXME")
+        print(tables_p.nodes)
+        print(tables_c.nodes)
+        self.assertEqual(tables_p.nodes, tables_c.nodes)
+        self.assertEqual(tables_p.edges, tables_c.edges)
+        self.assertEqual(tables_p.sites, tables_c.sites)
+        self.assertEqual(tables_p.mutations, tables_c.mutations)
 
     def test_single_tree(self):
         for seed in range(10):
@@ -897,7 +899,7 @@ class TestBadEngine(unittest.TestCase):
 
     def get_example(self):
         ts = msprime.simulate(10, mutation_rate=2, random_seed=3)
-        return formats.SampleData.from_tree_sequence(ts)
+        return tsinfer.SampleData.from_tree_sequence(ts)
 
     def test_infer(self):
         sample_data = self.get_example()
@@ -1158,15 +1160,19 @@ class TestMatchSiteSubsets(unittest.TestCase):
         self.verify(sample_data, position[:][::2])
 
 
-
-class TestPathCompression(unittest.TestCase):
+class PathCompressionMixin(object):
     """
     Common utilities for testing a tree sequence with path compression.
     """
     def verify_tree_sequence(self, ts):
+        num_fraction_times = sum(
+            math.floor(node.time) != node.time for node in ts.nodes())
         synthetic_nodes = [
-            node for node in ts.nodes() if math.floor(node.time) != node.time]
+            node for node in ts.nodes() if tsinfer.is_synthetic(node.flags)]
         self.assertGreater(len(synthetic_nodes), 0)
+        # Synthetic nodes will mostly have fractional times, so this number
+        # should at most the nuber of synthetic nodes.
+        self.assertGreaterEqual(len(synthetic_nodes), num_fraction_times)
         for node in synthetic_nodes:
             # print("Synthetic node", node)
             parent_edges = [edge for edge in ts.edges() if edge.parent == node.id]
@@ -1189,21 +1195,11 @@ class TestPathCompression(unittest.TestCase):
             original_matches = [
                 e for e in parent_edges if e.left == left and e.right == right]
             # We must have at least two initial edges that exactly span the
-            # synthetic interva.
+            # synthetic interval.
             self.assertGreater(len(original_matches), 1)
 
-
-class TestPathCompressionAncestors(TestPathCompression):
-    """
-    Tests for the results of path compression on an ancestors tree sequence.
-    """
-    def verify(self, sample_data):
-        ancestor_data = tsinfer.generate_ancestors(sample_data)
-        ts = tsinfer.match_ancestors(sample_data, ancestor_data, engine=tsinfer.PY_ENGINE)
-        self.verify_tree_sequence(ts)
-
     def test_simple_case(self):
-        ts = msprime.simulate(15, mutation_rate=8, random_seed=4, recombination_rate=8)
+        ts = msprime.simulate(55, mutation_rate=4, random_seed=4, recombination_rate=8)
         sample_data = tsinfer.SampleData.from_tree_sequence(ts)
         self.verify(sample_data)
 
@@ -1226,7 +1222,27 @@ class TestPathCompressionAncestors(TestPathCompression):
         self.verify(sample_data)
 
 
-class TestPathCompressionSamples(TestPathCompression):
+class PathCompressionAncestorsMixin(PathCompressionMixin):
+    """
+    Tests for the results of path compression on an ancestors tree sequence.
+    """
+    def verify(self, sample_data):
+        ancestor_data = tsinfer.generate_ancestors(sample_data)
+        ts = tsinfer.match_ancestors(sample_data, ancestor_data, engine=self.engine)
+        self.verify_tree_sequence(ts)
+
+
+class TestPathCompressionAncestorsPyEngine(
+        PathCompressionAncestorsMixin, unittest.TestCase):
+    engine = tsinfer.PY_ENGINE
+
+
+class TestPathCompressionAncestorsCEngine(
+        PathCompressionAncestorsMixin, unittest.TestCase):
+    engine = tsinfer.C_ENGINE
+
+
+class PathCompressionSamplesMixin(PathCompressionMixin):
     """
     Tests for the results of path compression just on samples.
     """
@@ -1237,34 +1253,21 @@ class TestPathCompressionSamples(TestPathCompression):
         ancestors_ts = tsinfer.match_ancestors(
             sample_data, ancestor_data, path_compression=False)
         ts = tsinfer.match_samples(
-            sample_data, ancestors_ts, path_compression=True, engine=tsinfer.PY_ENGINE)
+            sample_data, ancestors_ts, path_compression=True, engine=self.engine)
         self.verify_tree_sequence(ts)
 
-    def test_simple_case(self):
-        ts = msprime.simulate(55, mutation_rate=4, random_seed=4, recombination_rate=18)
-        sample_data = tsinfer.SampleData.from_tree_sequence(ts)
-        self.verify(sample_data)
 
-    def test_small_random_data(self):
-        n = 25
-        m = 20
-        G, positions = get_random_data_example(n, m)
-        with tsinfer.SampleData(sequence_length=m) as sample_data:
-            for genotypes, position in zip(G, positions):
-                sample_data.add_site(position, genotypes)
-        self.verify(sample_data)
-
-    def test_large_random_data(self):
-        n = 100
-        m = 30
-        G, positions = get_random_data_example(n, m)
-        with tsinfer.SampleData(sequence_length=m) as sample_data:
-            for genotypes, position in zip(G, positions):
-                sample_data.add_site(position, genotypes)
-        self.verify(sample_data)
+class TestPathCompressionSamplesPyEngine(
+        PathCompressionSamplesMixin, unittest.TestCase):
+    engine = tsinfer.PY_ENGINE
 
 
-class TestPathCompressionFullStack(TestPathCompression):
+class TestPathCompressionSamplesCEngine(
+        PathCompressionSamplesMixin, unittest.TestCase):
+    engine = tsinfer.C_ENGINE
+
+
+class PathCompressionFullStackMixin(PathCompressionMixin):
     """
     Tests for the results of path compression just on samples.
     """
@@ -1272,29 +1275,60 @@ class TestPathCompressionFullStack(TestPathCompression):
         # We have to turn off simplify because it'll sometimes remove chunks
         # of synthetic ancestors, breaking out continguity requirements.
         ts = tsinfer.infer(
-            sample_data, path_compression=True, engine=tsinfer.PY_ENGINE,
+            sample_data, path_compression=True, engine=self.engine,
             simplify=False)
         self.verify_tree_sequence(ts)
 
-    def test_simple_case(self):
-        ts = msprime.simulate(15, mutation_rate=5, random_seed=9, recombination_rate=10)
-        sample_data = tsinfer.SampleData.from_tree_sequence(ts)
-        self.verify(sample_data)
 
-    def test_small_random_data(self):
-        n = 25
-        m = 20
-        G, positions = get_random_data_example(n, m)
-        with tsinfer.SampleData(sequence_length=m) as sample_data:
-            for genotypes, position in zip(G, positions):
-                sample_data.add_site(position, genotypes)
-        self.verify(sample_data)
+class TestPathCompressionFullStackPyEngine(
+        PathCompressionFullStackMixin, unittest.TestCase):
+    engine = tsinfer.PY_ENGINE
 
-    def test_large_random_data(self):
-        n = 100
-        m = 30
-        G, positions = get_random_data_example(n, m)
-        with tsinfer.SampleData(sequence_length=m) as sample_data:
-            for genotypes, position in zip(G, positions):
-                sample_data.add_site(position, genotypes)
-        self.verify(sample_data)
+
+class TestPathCompressionFullStackCEngine(
+        PathCompressionFullStackMixin, unittest.TestCase):
+    engine = tsinfer.C_ENGINE
+
+
+class TestSyntheticFlag(unittest.TestCase):
+    """
+    Tests if we can set and detect the synthetic node flag correctly.
+    """
+    BIT_POSITION = 16
+
+    def test_is_synthetic(self):
+        self.assertFalse(tsinfer.is_synthetic(0))
+        self.assertFalse(tsinfer.is_synthetic(1))
+        self.assertTrue(tsinfer.is_synthetic(tsinfer.SYNTHETIC_NODE_BIT))
+        for bit in range(32):
+            flags = 1 << bit
+            if bit == self.BIT_POSITION:
+                self.assertTrue(tsinfer.is_synthetic(flags))
+            else:
+                self.assertFalse(tsinfer.is_synthetic(flags))
+        flags = tsinfer.SYNTHETIC_NODE_BIT
+        for bit in range(32):
+            flags |= 1 << bit
+            self.assertTrue(tsinfer.is_synthetic(flags))
+        flags = 0
+        for bit in range(32):
+            if bit != self.BIT_POSITION:
+                flags |= 1 << bit
+            self.assertFalse(tsinfer.is_synthetic(flags))
+
+    def test_count_synthetic(self):
+        self.assertEqual(tsinfer.count_synthetic([0]), 0)
+        self.assertEqual(tsinfer.count_synthetic([tsinfer.SYNTHETIC_NODE_BIT]), 1)
+        self.assertEqual(tsinfer.count_synthetic([0, 0]), 0)
+        self.assertEqual(tsinfer.count_synthetic([0, tsinfer.SYNTHETIC_NODE_BIT]), 1)
+        self.assertEqual(tsinfer.count_synthetic(
+            [tsinfer.SYNTHETIC_NODE_BIT, tsinfer.SYNTHETIC_NODE_BIT]), 2)
+        self.assertEqual(tsinfer.count_synthetic([1, tsinfer.SYNTHETIC_NODE_BIT]), 1)
+        self.assertEqual(tsinfer.count_synthetic(
+            [1 | tsinfer.SYNTHETIC_NODE_BIT, 1 | tsinfer.SYNTHETIC_NODE_BIT]), 2)
+
+    def test_count_synthetic_random(self):
+        np.random.seed(42)
+        flags = np.random.randint(0, high=2**32, size=100, dtype=np.uint32)
+        count = sum(map(tsinfer.is_synthetic, flags))
+        self.assertEqual(count, tsinfer.count_synthetic(flags))

--- a/tsinfer/algorithm.py
+++ b/tsinfer/algorithm.py
@@ -349,6 +349,7 @@ class TreeSequenceBuilder(object):
             prev = edge
 
         if compress:
+            # print("Compressing path for ", child)
             head = self.compress_path(head)
 
         # Insert the chain into the global state.

--- a/tsinfer/constants.py
+++ b/tsinfer/constants.py
@@ -17,26 +17,14 @@
 # along with tsinfer.  If not, see <http://www.gnu.org/licenses/>.
 #
 """
-Tree sequence inference.
-
-Python 3 only.
+Collection of constants used in tsinfer.
 """
 
-import sys
+UNKNOWN_ALLELE = 255
 
-if sys.version_info[0] < 3:
-    raise Exception("Python 3 only")
+C_ENGINE = "C"
+PY_ENGINE = "P"
 
-__version__ = "undefined"
-try:
-    from . import _version
-    __version__ = _version.version
-except ImportError:
-    pass
-
-from .inference import *  # NOQA
-from .formats import *  # NOQA
-from .eval_util import *  # NOQA
-from .exceptions import *  # NOQA
-from .constants import *  # NOQA
-from .cli import get_cli_parser  # NOQA
+# This bit is set in the flags if the node is synthetic, i.e., has been
+# created by path compression.
+SYNTHETIC_NODE_FLAG = 16

--- a/tsinfer/constants.py
+++ b/tsinfer/constants.py
@@ -25,6 +25,5 @@ UNKNOWN_ALLELE = 255
 C_ENGINE = "C"
 PY_ENGINE = "P"
 
-# This bit is set in the flags if the node is synthetic, i.e., has been
-# created by path compression.
-SYNTHETIC_NODE_FLAG = 16
+# Bit 16 is set in node flags when they have been created by path compression.
+SYNTHETIC_NODE_BIT = 1 << 16

--- a/tsinfer/eval_util.py
+++ b/tsinfer/eval_util.py
@@ -29,6 +29,7 @@ import msprime
 
 import tsinfer.inference as inference
 import tsinfer.formats as formats
+import tsinfer.constants as constants
 
 
 def insert_errors(ts, probability, seed=None):
@@ -271,7 +272,7 @@ def get_ancestral_haplotypes(ts):
     B = tsp.genotype_matrix().T
 
     A = np.zeros((ts.num_nodes, ts.num_sites), dtype=np.uint8)
-    A[:] = inference.UNKNOWN_ALLELE
+    A[:] = constants.UNKNOWN_ALLELE
     for edge in ts.edges():
         start = bisect.bisect_left(sites, edge.left)
         end = bisect.bisect_right(sites, edge.right)
@@ -307,14 +308,14 @@ def get_ancestor_descriptors(A):
         masked = np.logical_and(a == 1, mask).astype(int)
         new_sites = np.where(masked)[0]
         mask[new_sites] = 0
-        segment = np.where(a != inference.UNKNOWN_ALLELE)[0]
+        segment = np.where(a != constants.UNKNOWN_ALLELE)[0]
         # Skip any ancestors that are entirely unknown
         if segment.shape[0] > 0:
             s = segment[0]
             e = segment[-1] + 1
-            assert np.all(a[s:e] != inference.UNKNOWN_ALLELE)
-            assert np.all(a[:s] == inference.UNKNOWN_ALLELE)
-            assert np.all(a[e:] == inference.UNKNOWN_ALLELE)
+            assert np.all(a[s:e] != constants.UNKNOWN_ALLELE)
+            assert np.all(a[:s] == constants.UNKNOWN_ALLELE)
+            assert np.all(a[e:] == constants.UNKNOWN_ALLELE)
             ancestors.append(a)
             focal_sites.append(new_sites)
             start.append(s)
@@ -378,9 +379,9 @@ def build_simulated_ancestors(sample_data, ancestor_data, ts, time_chunking=Fals
         time = np.arange(N)
     time = -1 * (time - time[-1]) + 1
     for a, s, e, focal, t in zip(ancestors, start, end, focal_sites, time):
-        assert np.all(a[:s] == inference.UNKNOWN_ALLELE)
-        assert np.all(a[s:e] != inference.UNKNOWN_ALLELE)
-        assert np.all(a[e:] == inference.UNKNOWN_ALLELE)
+        assert np.all(a[:s] == constants.UNKNOWN_ALLELE)
+        assert np.all(a[s:e] != constants.UNKNOWN_ALLELE)
+        assert np.all(a[e:] == constants.UNKNOWN_ALLELE)
         assert all(s <= site < e for site in focal)
         ancestor_data.add_ancestor(
             start=s, end=e, time=t, focal_sites=np.array(focal, dtype=np.int32),
@@ -431,7 +432,7 @@ def print_tree_pairs(ts1, ts2, compute_distances=True):
 def run_perfect_inference(
         base_ts, num_threads=1, path_compression=False,
         extended_checks=True, time_chunking=True, progress_monitor=None,
-        engine=inference.C_ENGINE):
+        engine=constants.C_ENGINE):
     """
     Runs the perfect inference process on the specified tree sequence.
     """

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -38,12 +38,9 @@ import tsinfer.formats as formats
 import tsinfer.algorithm as algorithm
 import tsinfer.threads as threads
 import tsinfer.provenance as provenance
+import tsinfer.constants as constants
 
 logger = logging.getLogger(__name__)
-
-UNKNOWN_ALLELE = 255
-C_ENGINE = "C"
-PY_ENGINE = "P"
 
 
 class DummyProgress(object):
@@ -76,7 +73,7 @@ def _get_progress_monitor(progress_monitor):
 
 def infer(
         sample_data, progress_monitor=None, num_threads=0, path_compression=True,
-        simplify=True, engine=C_ENGINE):
+        simplify=True, engine=constants.C_ENGINE):
     """
     infer(sample_data, num_threads=0)
 
@@ -107,7 +104,8 @@ def infer(
 
 
 def generate_ancestors(
-        sample_data, num_threads=0, progress_monitor=None, engine=C_ENGINE, **kwargs):
+        sample_data, num_threads=0, progress_monitor=None, engine=constants.C_ENGINE,
+        **kwargs):
     """
     generate_ancestors(sample_data, num_threads=0, path=None, **kwargs)
 
@@ -143,7 +141,7 @@ def generate_ancestors(
 
 def match_ancestors(
         sample_data, ancestor_data, progress_monitor=None, num_threads=0,
-        path_compression=True, extended_checks=False, engine=C_ENGINE):
+        path_compression=True, extended_checks=False, engine=constants.C_ENGINE):
     """
     match_ancestors(sample_data, path_compression, num_threads=0)
 
@@ -173,7 +171,7 @@ def match_ancestors(
 def match_samples(
         sample_data, ancestors_ts, progress_monitor=None, num_threads=0,
         path_compression=True, simplify=True, extended_checks=False,
-        stabilise_node_ordering=False, engine=C_ENGINE):
+        stabilise_node_ordering=False, engine=constants.C_ENGINE):
     """
     match_samples(sample_data, ancestors_ts, num_threads=0, simplify=True)
 
@@ -217,11 +215,11 @@ class AncestorsGenerator(object):
         self.num_sites = sample_data.num_inference_sites
         self.num_samples = sample_data.num_samples
         self.num_threads = num_threads
-        if engine == C_ENGINE:
+        if engine == constants.C_ENGINE:
             logger.debug("Using C AncestorBuilder implementation")
             self.ancestor_builder = _tsinfer.AncestorBuilder(
                 self.num_samples, self.num_sites)
-        elif engine == PY_ENGINE:
+        elif engine == constants.PY_ENGINE:
             logger.debug("Using Python AncestorBuilder implementation")
             self.ancestor_builder = algorithm.AncestorBuilder(
                 self.num_samples, self.num_sites)
@@ -349,7 +347,7 @@ class AncestorsGenerator(object):
 class Matcher(object):
 
     def __init__(
-            self, sample_data, num_threads=1, engine=C_ENGINE,
+            self, sample_data, num_threads=1, engine=constants.C_ENGINE,
             path_compression=True, progress_monitor=None, extended_checks=False):
         self.sample_data = sample_data
         self.num_threads = num_threads
@@ -360,11 +358,11 @@ class Matcher(object):
         self.match_progress = None  # Allocated by subclass
         self.extended_checks = extended_checks
 
-        if engine == C_ENGINE:
+        if engine == constants.C_ENGINE:
             logger.debug("Using C matcher implementation")
             self.tree_sequence_builder_class = _tsinfer.TreeSequenceBuilder
             self.ancestor_matcher_class = _tsinfer.AncestorMatcher
-        elif engine == PY_ENGINE:
+        elif engine == constants.PY_ENGINE:
             logger.debug("Using Python matcher implementation")
             self.tree_sequence_builder_class = algorithm.TreeSequenceBuilder
             self.ancestor_matcher_class = algorithm.AncestorMatcher
@@ -464,6 +462,7 @@ class Matcher(object):
         tsb = self.tree_sequence_builder
         tables = msprime.TableCollection(
             sequence_length=self.ancestor_data.sequence_length)
+
         flags, time = tsb.dump_nodes()
         num_synthetic_nodes = np.sum(flags == 0)
         tables.nodes.set_columns(flags=flags, time=time)
@@ -726,7 +725,7 @@ class AncestorMatcher(Matcher):
         ])
 
     def __ancestor_find_path(self, ancestor, thread_index=0):
-        haplotype = np.zeros(self.num_sites, dtype=np.uint8) + UNKNOWN_ALLELE
+        haplotype = np.zeros(self.num_sites, dtype=np.uint8) + constants.UNKNOWN_ALLELE
         focal_sites = ancestor.focal_sites
         start = ancestor.start
         end = ancestor.end


### PR DESCRIPTION
Current path compression can have arbitrary discontinuities within paths. This fixes it to ensure that we only ever use contiguous paths to create synthetic nodes.