### PR TITLE
Tools for checking ancestors tree sequences for validity

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -113,14 +113,9 @@ def tsinfer_dev(
         print("num_sites = ", ts.num_sites)
     assert ts.num_sites > 0
 
-    ts = tsinfer.eval_util.insert_perfect_mutations(ts)
+    samples = tsinfer.SampleData.from_tree_sequence(ts)
 
-    sample_data = tsinfer.SampleData.from_tree_sequence(ts)
-
-    # Reduce and minimise the input ts so that we can use it as
-    # input.
-    position = sample_data.sites_position[:][sample_data.sites_inference[:] == 1]
-    ancestors_ts = make_ancestors_ts(ts, position, remove_leaves=False)
+    ancestors_ts = tsinfer.make_ancestors_ts(samples, ts, remove_leaves=False)
 
 
 #     ancestor_data = tsinfer.generate_ancestors(
@@ -136,7 +131,7 @@ def tsinfer_dev(
 
 
 
-    ts = tsinfer.match_samples(sample_data, ancestors_ts,
+    ts = tsinfer.match_samples(samples, ancestors_ts,
             path_compression=False, simplify=False, engine=engine,
             extended_checks=True)
 
@@ -144,7 +139,7 @@ def tsinfer_dev(
     for tree in ts.trees():
         print(tree.draw(format="unicode"))
 
-    tsinfer.verify(sample_data, ts)
+    tsinfer.verify(samples, ts)
 
 
 #     for node in ts.nodes():
@@ -290,7 +285,7 @@ if __name__ == "__main__":
     # for j in range(1, 100):
     #     tsinfer_dev(15, 0.5, seed=j, num_threads=0, engine="P", recombination_rate=1e-8)
     # copy_1kg()
-    tsinfer_dev(5, 0.05, seed=4, num_threads=0, engine="P", recombination_rate=1e-8)
+    tsinfer_dev(3, 0.05, seed=4, num_threads=0, engine="C", recombination_rate=1e-8)
 
     # minimise_dev()
 

--- a/dev.py
+++ b/dev.py
@@ -94,7 +94,6 @@ def generate_samples(ts, error_p):
             done = 0 < s < ts.sample_size
     return S.T
 
-
 def tsinfer_dev(
         n, L, seed, num_threads=1, recombination_rate=1e-8,
         error_rate=0, engine="C", log_level="WARNING",
@@ -114,30 +113,52 @@ def tsinfer_dev(
         print("num_sites = ", ts.num_sites)
     assert ts.num_sites > 0
 
+    ts = tsinfer.eval_util.insert_perfect_mutations(ts)
+
     sample_data = tsinfer.SampleData.from_tree_sequence(ts)
 
-    ancestor_data = tsinfer.generate_ancestors(
-        sample_data, engine=engine, num_threads=num_threads)
-    ancestors_ts = tsinfer.match_ancestors(
-        sample_data, ancestor_data, engine=engine, path_compression=True,
-        extended_checks=True)
+    # Reduce and minimise the input ts so that we can use it as
+    # input.
+    position = sample_data.sites_position[:][sample_data.sites_inference[:] == 1]
+    ancestors_ts = make_ancestors_ts(ts, position, remove_leaves=False)
+
+
+#     ancestor_data = tsinfer.generate_ancestors(
+#         sample_data, engine=engine, num_threads=num_threads)
+#     ancestors_ts = tsinfer.match_ancestors(
+#         sample_data, ancestor_data, engine=engine, path_compression=True,
+#         extended_checks=True)
+
+    for tree in ancestors_ts.trees():
+        for site in tree.sites():
+            print("Mutation at ", site.mutations[0].node)
+        print(tree.draw(format="unicode"))
+
+
 
     ts = tsinfer.match_samples(sample_data, ancestors_ts,
-            path_compression=True, simplify=False, engine=engine,
+            path_compression=False, simplify=False, engine=engine,
             extended_checks=True)
 
-    for node in ts.nodes():
-        if tsinfer.is_synthetic(node.flags):
-            print("Synthetic node", node.id, node.time)
-            parent_edges = [edge for edge in ts.edges() if edge.parent == node.id]
-            child_edges = [edge for edge in ts.edges() if edge.child == node.id]
-            child_edges.sort(key=lambda e: e.left)
-            print("parent edges")
-            for edge in parent_edges:
-                print("\t", edge)
-            print("child edges")
-            for edge in child_edges:
-                print("\t", edge)
+    # print(ts.tables.edges)
+    for tree in ts.trees():
+        print(tree.draw(format="unicode"))
+
+    tsinfer.verify(sample_data, ts)
+
+
+#     for node in ts.nodes():
+#         if tsinfer.is_synthetic(node.flags):
+#             print("Synthetic node", node.id, node.time)
+#             parent_edges = [edge for edge in ts.edges() if edge.parent == node.id]
+#             child_edges = [edge for edge in ts.edges() if edge.child == node.id]
+#             child_edges.sort(key=lambda e: e.left)
+#             print("parent edges")
+#             for edge in parent_edges:
+#                 print("\t", edge)
+#             print("child edges")
+#             for edge in child_edges:
+#                 print("\t", edge)
 
 #     # output_ts = tsinfer.match_samples(subset_samples, ancestors_ts, engine=engine)
 #     output_ts = tsinfer.match_samples(sample_data, ancestors_ts, engine=engine)
@@ -244,84 +265,6 @@ def subset_sites(ts, position):
                     metadata=mutation.metadata)
     return tables.tree_sequence()
 
-def minimise(ts):
-    tables = ts.dump_tables()
-
-    out_map = {}
-    in_map = {}
-    first_site = 0
-    for (_, edges_out, edges_in), tree in zip(ts.edge_diffs(), ts.trees()):
-        for edge in edges_out:
-            out_map[edge.child] = edge
-        for edge in edges_in:
-            in_map[edge.child] = edge
-        if tree.num_sites > 0:
-            sites = list(tree.sites())
-            if first_site:
-                x = 0
-                first_site = False
-            else:
-                x = sites[0].position
-            print("X = ", x)
-            for edge in out_map.values():
-                print("FLUSH", edge)
-            for edge in in_map.values():
-                print("INSER", edge)
-
-            # # Flush the edge buffer.
-            # for left, parent, child in edge_buffer:
-            #     tables.edges.add_row(left, x, parent, child)
-            # # Add edges for each node in the tree.
-            # edge_buffer.clear()
-            # for root in tree.roots:
-            #     for u in tree.nodes(root):
-            #         if u != root:
-            #             edge_buffer.append((x, tree.parent(u), u))
-
-    # position = np.hstack([[0], tables.sites.position, [ts.sequence_length]])
-    # position = tables.sites.position
-    # edges = []
-    # print(position)
-    # tables.edges.clear()
-    # for edge in ts.edges():
-    #     left = np.searchsorted(position, edge.left)
-    #     right = np.searchsorted(position, edge.right)
-
-    #     print(edge, left, right)
-    #     # if right - left > 1:
-    #         # print("KEEP:", edge, left, right)
-    #         # tables.edges.add_row(
-    #         #     position[left], position[right], edge.parent, edge.child)
-    #         # print("added", tables.edges[-1])
-    #     # else:
-    #         # print("SKIP:", edge, left, right)
-
-    # ts = tables.tree_sequence()
-    # for tree in ts.trees():
-    #     print("TREE:", tree.interval)
-    #     print(tree.draw(format="unicode"))
-
-
-
-
-
-def minimise_dev():
-    ts = msprime.simulate(5, mutation_rate=1, recombination_rate=2, random_seed=3)
-    # ts = msprime.load(sys.argv[1])
-
-    position = ts.tables.sites.position[::2]
-    subset_ts = subset_sites(ts, position)
-    print("Got subset")
-
-    ts_new = tsinfer.minimise(subset_ts)
-    for tree in ts_new.trees():
-        print("TREE:", tree.interval)
-        print(tree.draw(format="unicode"))
-    # print(ts_new.tables)
-    print("done")
-    other = minimise(subset_ts)
-
-
 def run_build():
 
     sample_data = tsinfer.load(sys.argv[1])
@@ -347,7 +290,7 @@ if __name__ == "__main__":
     # for j in range(1, 100):
     #     tsinfer_dev(15, 0.5, seed=j, num_threads=0, engine="P", recombination_rate=1e-8)
     # copy_1kg()
-    tsinfer_dev(20, 0.25, seed=4, num_threads=0, engine="C", recombination_rate=1e-8)
+    tsinfer_dev(5, 0.05, seed=4, num_threads=0, engine="P", recombination_rate=1e-8)
 
     # minimise_dev()
 

--- a/lib/ancestor_matcher.c
+++ b/lib/ancestor_matcher.c
@@ -242,14 +242,10 @@ is_descendant(const node_id_t u, const node_id_t v, const node_id_t *restrict pa
     node_id_t w = u;
 
     if (v != NULL_NODE) {
-        /* Because we allocate node IDs in nondecreasing order forwards in time,
-         * if the node ID is of u is less than v it cannot be a descendant of v */
-        if (u >= v) {
-            while (w != NULL_NODE && w != v) {
-                w = parent[w];
-            }
-            ret = w == v;
+        while (w != NULL_NODE && w != v) {
+            w = parent[w];
         }
+        ret = w == v;
     }
     return ret;
 }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,6 +160,40 @@ class TestCommandsDefaults(TestCli):
         self.run_command(["match-samples", self.sample_file, "-O", output_trees])
         self.verify_output(output_trees)
 
+    def test_verify(self):
+        output_trees = os.path.join(self.tempdir.name, "output.trees")
+        self.run_command(["infer", self.sample_file, "-O", output_trees])
+        self.run_command(["verify", self.sample_file, output_trees])
+
+
+class TestProgress(TestCli):
+    """
+    Tests that we get some output when we use the progress bar.
+    """
+    # Need to mock out setup_logging here or we spew logging to the console
+    # in later tests.
+    @mock.patch("tsinfer.cli.setup_logging")
+    def run_command(self, command, mock_setup_logging):
+        stdout, stderr = capture_output(cli.tsinfer_main, command + ["--progress"])
+        self.assertGreater(len(stderr), 0)
+        self.assertEqual(stdout, "")
+        self.assertTrue(mock_setup_logging.called)
+
+    def test_infer(self):
+        output_trees = os.path.join(self.tempdir.name, "output.trees")
+        self.run_command(["infer", self.sample_file, "-O", output_trees])
+
+    def test_nominal_chain(self):
+        output_trees = os.path.join(self.tempdir.name, "output.trees")
+        self.run_command(["generate-ancestors", self.sample_file])
+        self.run_command(["match-ancestors", self.sample_file])
+        self.run_command(["match-samples", self.sample_file, "-O", output_trees])
+
+    def test_verify(self):
+        output_trees = os.path.join(self.tempdir.name, "output.trees")
+        self.run_command(["infer", self.sample_file, "-O", output_trees])
+        self.run_command(["verify", self.sample_file, output_trees])
+
 
 class TestMatchSamples(TestCli):
     """

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -605,6 +605,124 @@ class TestPerfectInference(unittest.TestCase):
             self.verify_perfect_inference(ts, inferred_ts)
 
 
+class TestMakeAncestorsTs(unittest.TestCase):
+    """
+    Tests for the process of generating an ancestors tree sequence.
+    """
+    def verify_from_source(self, remove_leaves):
+        ts = msprime.simulate(15, recombination_rate=1, mutation_rate=2, random_seed=3)
+        samples = tsinfer.SampleData.from_tree_sequence(ts)
+        ancestors_ts = tsinfer.make_ancestors_ts(
+            samples, ts, remove_leaves=remove_leaves)
+        tsinfer.check_ancestors_ts(ancestors_ts)
+        for engine in [tsinfer.PY_ENGINE, tsinfer.C_ENGINE]:
+            final_ts = tsinfer.match_samples(samples, ancestors_ts, engine=engine)
+        tsinfer.verify(samples, final_ts)
+
+    def test_infer_from_source_no_leaves(self):
+        self.verify_from_source(True)
+
+    def test_infer_from_source(self):
+        self.verify_from_source(True)
+
+    def verify_from_inferred(self, remove_leaves):
+        ts = msprime.simulate(15, recombination_rate=1, mutation_rate=2, random_seed=3)
+        samples = tsinfer.SampleData.from_tree_sequence(ts)
+        inferred = tsinfer.infer(samples)
+        ancestors_ts = tsinfer.make_ancestors_ts(
+            samples, inferred, remove_leaves=remove_leaves)
+        tsinfer.check_ancestors_ts(ancestors_ts)
+        for engine in [tsinfer.PY_ENGINE, tsinfer.C_ENGINE]:
+            final_ts = tsinfer.match_samples(samples, ancestors_ts, engine=engine)
+        tsinfer.verify(samples, final_ts)
+
+    def test_infer_from_inferred_no_leaves(self):
+        self.verify_from_inferred(True)
+
+    def test_infer_from_inferred(self):
+        self.verify_from_inferred(False)
+
+
+class TestCheckAncestorsTs(unittest.TestCase):
+    """
+    Tests that we verify the right conditions from an ancestors TS.
+    """
+
+    def test_empty(self):
+        tables = msprime.TableCollection(1)
+        tsinfer.check_ancestors_ts(tables.tree_sequence())
+
+    def test_zero_time(self):
+        tables = msprime.TableCollection(1)
+        tables.nodes.add_row(time=0, flags=0)
+        with self.assertRaises(ValueError):
+            tsinfer.check_ancestors_ts(tables.tree_sequence())
+
+    def test_zero_edges(self):
+        tables = msprime.TableCollection(1)
+        tables.nodes.add_row(time=1, flags=0)
+        with self.assertRaises(ValueError):
+            tsinfer.check_ancestors_ts(tables.tree_sequence())
+
+    def test_one_edge(self):
+        tables = msprime.TableCollection(1)
+        tables.nodes.add_row(time=2, flags=0)
+        tables.nodes.add_row(time=1, flags=0)
+        tables.edges.add_row(0, 1, 0, 1)
+        tsinfer.check_ancestors_ts(tables.tree_sequence())
+
+    def test_zero_has_parent(self):
+        tables = msprime.TableCollection(1)
+        tables.nodes.add_row(time=1, flags=0)
+        tables.nodes.add_row(time=2, flags=0)
+        tables.edges.add_row(0, 1, 1, 0)
+        with self.assertRaises(ValueError):
+            tsinfer.check_ancestors_ts(tables.tree_sequence())
+
+    def test_zero_has_no_children(self):
+        tables = msprime.TableCollection(1)
+        tables.nodes.add_row(time=1, flags=0)
+        tables.nodes.add_row(time=2, flags=0)
+        tables.nodes.add_row(time=3, flags=0)
+        tables.edges.add_row(0, 1, 2, 1)
+        with self.assertRaises(ValueError):
+            tsinfer.check_ancestors_ts(tables.tree_sequence())
+
+    def test_disconnected_subtrees(self):
+        tables = msprime.TableCollection(1)
+        tables.nodes.add_row(time=4, flags=1)
+        tables.nodes.add_row(time=3, flags=1)
+        tables.nodes.add_row(time=2, flags=1)
+        tables.nodes.add_row(time=1, flags=1)
+        tables.edges.add_row(0, 1, 2, 3)
+        tables.edges.add_row(0, 1, 0, 1)
+        with self.assertRaises(ValueError):
+            tsinfer.check_ancestors_ts(tables.tree_sequence())
+
+    def test_many_mutations(self):
+        tables = msprime.TableCollection(1)
+        tables.nodes.add_row(time=2, flags=0)
+        tables.nodes.add_row(time=1, flags=0)
+        tables.edges.add_row(0, 1, 0, 1)
+        tables.sites.add_row(position=0.5, ancestral_state="0")
+        tables.mutations.add_row(site=0, node=0, derived_state="1")
+        tables.mutations.add_row(site=0, node=1, derived_state="0")
+        with self.assertRaises(ValueError):
+            tsinfer.check_ancestors_ts(tables.tree_sequence())
+
+    def test_msprime_output(self):
+        ts = msprime.simulate(10, mutation_rate=1, random_seed=1)
+        with self.assertRaises(ValueError):
+            tsinfer.check_ancestors_ts(ts)
+
+    def test_tsinfer_output(self):
+        ts = msprime.simulate(10, mutation_rate=1, random_seed=1)
+        samples = tsinfer.SampleData.from_tree_sequence(ts)
+        ts = tsinfer.infer(samples)
+        with self.assertRaises(ValueError):
+            tsinfer.check_ancestors_ts(ts)
+
+
 class TestErrors(unittest.TestCase):
     """
     Tests for the error generation code.

--- a/tsinfer/algorithm.py
+++ b/tsinfer/algorithm.py
@@ -594,8 +594,6 @@ def is_descendant(pi, u, v):
             w = pi[w]
         # print("DESC:",v, u, path)
         ret = w == v
-    if u < v:
-        assert not ret
     # print("IS_DESCENDENT(", u, v, ") = ", ret)
     return ret
 

--- a/tsinfer/algorithm.py
+++ b/tsinfer/algorithm.py
@@ -509,7 +509,7 @@ class TreeSequenceBuilder(object):
                 assert edge.child == child
                 if edge.next is not None:
                     if self.flags[child] != 0:
-                        assert edge.next.left == edge.right
+                        assert edge.next.left >= edge.right
                 assert self.left_index[(edge.left, self.time[child], child)] == edge
                 assert self.right_index[(edge.right, -self.time[child], child)] == edge
                 edge = edge.next

--- a/tsinfer/eval_util.py
+++ b/tsinfer/eval_util.py
@@ -470,8 +470,8 @@ def make_ancestors_ts(ts, sample_data, remove_leaves=False):
     tables.nodes.clear()
     tables.nodes.add_row(flags=1, time=np.max(nodes.time) + 2)
     tables.nodes.append_columns(
-        flags=np.ones_like(nodes.flags), # Everything is a sample
-        time=nodes.time + 1, # Make sure that all times are > 0
+        flags=np.ones_like(nodes.flags),  # Everything is a sample
+        time=nodes.time + 1,  # Make sure that all times are > 0
         population=nodes.population,
         individual=nodes.individual, metadata=nodes.metadata,
         metadata_offset=nodes.metadata_offset)

--- a/tsinfer/eval_util.py
+++ b/tsinfer/eval_util.py
@@ -460,14 +460,9 @@ def make_ancestors_ts(samples, ts, remove_leaves=False):
     We generally assume that this is a standard tree sequence output by
     msprime.simulate here.
     """
-    for tree in ts.trees():
-        print(tree.draw(format="unicode"))
     position = samples.sites_position[:][samples.sites_inference[:] == 1]
     reduced = subset_sites(ts, position)
     minimised = inference.minimise(reduced)
-
-    for tree in minimised.trees():
-        print(tree.draw(format="unicode"))
 
     tables = minimised.dump_tables()
     # Rewrite the nodes so that 0 is one older than all the other nodes.

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -121,19 +121,27 @@ def _get_progress_monitor(progress_monitor):
     return progress_monitor
 
 
-def verify(sample_data, tree_sequence):
+def verify(samples, tree_sequence, progress_monitor=None):
     """
+    verify(samples, tree_sequence)
+
     Verifies that the specified sample data and tree sequence files encode the
     same data.
+
+    :param SampleData samples: The input :class:`SampleData` instance
+        representing the observed data that we wish to compare to.
+    :param TreeSequence tree_sequence: The input :class:`msprime.TreeSequence`
+        instance an encoding of the specified samples that we wish to verify.
     """
-    if sample_data.num_sites != tree_sequence.num_sites:
+    progress_monitor = _get_progress_monitor(progress_monitor)
+    if samples.num_sites != tree_sequence.num_sites:
         raise ValueError("numbers of sites not equal")
-    if sample_data.num_samples != tree_sequence.num_samples:
+    if samples.num_samples != tree_sequence.num_samples:
         raise ValueError("numbers of samples not equal")
-    for var1, var2 in zip(sample_data.variants(), tree_sequence.variants()):
-        if var1.site.id != var2.site.id:
-            raise ValueError("site IDs not equal: {} != {}".format(
-                var1.site.id, var2.site.id))
+    if samples.sequence_length != tree_sequence.sequence_length:
+        raise ValueError("Sequence lengths not equal")
+    progress = progress_monitor.get("verify", tree_sequence.num_sites)
+    for var1, var2 in zip(samples.variants(), tree_sequence.variants()):
         if var1.site.position != var2.site.position:
             raise ValueError("site positions not equal: {} != {}".format(
                 var1.site.position, var2.site.position))
@@ -142,6 +150,8 @@ def verify(sample_data, tree_sequence):
                 var1.alleles, var2.alleles))
         if not np.array_equal(var1.genotypes, var2.genotypes):
             raise ValueError("Genotypes not equal at site {}".format(var1.site.id))
+        progress.update()
+    progress.close()
 
 
 def infer(

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -43,39 +43,6 @@ import tsinfer.constants as constants
 logger = logging.getLogger(__name__)
 
 
-def check_ancestors_ts(ts):
-    """
-    Checks if the specified tree sequence has the required properties for an
-    ancestors tree sequence.
-    """
-    if ts.num_nodes == 0:
-        return
-    tables = ts.tables
-    if np.any(tables.nodes.time <= 0):
-        raise ValueError("All nodes must have time > 0")
-    # This is a strong requirement, which is only partially true. It seems to be
-    # fine if we have synthetic nodes which are out-of-order. Why?
-    # # Nodes must be in nondecreasing order of time.
-    # time = tables.nodes.time
-    # if np.any(time[:-1] < time[1:]):
-    #     raise ValueError("Nodes must be allocated in non-decreasing time order.")
-
-    for tree in ts.trees(sample_counts=False):
-        # 0 must always be a root and have at least one child.
-        if tree.parent(0) != msprime.NULL_NODE:
-            raise ValueError("0 is not a root: non null parent")
-        if tree.left_child(0) == msprime.NULL_NODE:
-            raise ValueError("0 must have at least one child")
-        for root in tree.roots:
-            if root != 0:
-                if tree.left_child(root) != msprime.NULL_NODE:
-                    raise ValueError("All non empty subtrees must inherit from 0")
-        # Sites must have exactly one mutation
-        for site in tree.sites():
-            if len(site.mutations) != 1:
-                raise ValueError("Sites must have exactly one mutation")
-
-
 def is_synthetic(flags):
     """
     Returns True if the synthetic flag is set on the specified flags


### PR DESCRIPTION
This will interest you @hyanwong --- there's some code in here for checking the properties of a tree sequence to ensure that it's a valid ancestors_ts. I've also added a method to take any tree sequence and modify it so that it can be used as an ancestors tree sequence in sample matching (i.e., this allows us to match samples against  the original tree sequence). A nice consequence of this is that it gives us another way of doing perfect inference, without needed the input to have SMC properties.

The ``check_ancestors_ts`` should enumerate the required properties. One thing I've not resolved is that there seems to be a partial dependence on the time of nodes being sorted. You can use the trick
```python
tables.simplify(samples=np.argsort(tables.nodes.time)[::-1].astype(np.int32))
```
to make sure that it's true if you're still having issues with your constructed tree sequences.