### PR TITLE
Allow edges-performance test to use different engines

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -139,7 +139,7 @@ def run_infer(ts, engine=tsinfer.C_ENGINE, path_compression=True, exact_ancestor
         tsinfer.build_simulated_ancestors(sample_data, ancestor_data, ts)
         ancestor_data.finalise()
     else:
-        ancestor_data = tsinfer.generate_ancestors(sample_data)
+        ancestor_data = tsinfer.generate_ancestors(sample_data, engine=engine)
 
     ancestors_ts = tsinfer.match_ancestors(
         sample_data, ancestor_data, path_compression=path_compression,
@@ -151,7 +151,7 @@ def run_infer(ts, engine=tsinfer.C_ENGINE, path_compression=True, exact_ancestor
 
 
 def edges_performance_worker(args):
-    simulation_args, tree_metrics = args
+    simulation_args, tree_metrics, engine = args
     before = time.perf_counter()
     smc_ts = msprime.simulate(**simulation_args)
     sim_time = time.perf_counter() - before
@@ -162,7 +162,7 @@ def edges_performance_worker(args):
         return {}
 
     before = time.perf_counter()
-    estimated_ancestors_ts = run_infer(smc_ts, exact_ancestors=False)
+    estimated_ancestors_ts = run_infer(smc_ts, exact_ancestors=False, engine=engine)
     estimated_ancestors_time = time.perf_counter() - before
     num_children = []
     for edgeset in estimated_ancestors_ts.edgesets():
@@ -170,7 +170,7 @@ def edges_performance_worker(args):
     estimated_ancestors_num_children = np.array(num_children)
 
     before = time.perf_counter()
-    exact_ancestors_ts = run_infer(smc_ts, exact_ancestors=True)
+    exact_ancestors_ts = run_infer(smc_ts, exact_ancestors=True, engine=engine)
     exact_ancestors_time = time.perf_counter() - before
     num_children = []
     for edgeset in exact_ancestors_ts.edgesets():
@@ -241,7 +241,7 @@ def run_edges_performance(args):
                 "Ne": 10**4,
                 "model": "smc_prime",
                 "random_seed": rng.randint(1, 2**30)}
-            work.append((sim_args, args.compute_tree_metrics))
+            work.append((sim_args, args.compute_tree_metrics, args.engine))
 
     random.shuffle(work)
     progress = tqdm.tqdm(total=len(work), disable=not args.progress)
@@ -1276,7 +1276,7 @@ def run_node_degree(args):
         "random_seed": rng.randint(1, 2**30)}
     smc_ts = msprime.simulate(**sim_args)
 
-    engine = tsinfer.C_ENGINE
+    engine = args.engine
     df = pd.DataFrame()
     for path_compression in [True, False]:
         estimated_ancestors_ts = run_infer(


### PR DESCRIPTION
This is a relatively simple change that only touches the evaluation tests