### PR TITLE
Switch to (signed) int8 for haplotype storage

### DIFF
--- a/_tsinfermodule.c
+++ b/_tsinfermodule.c
@@ -123,7 +123,7 @@ AncestorBuilder_add_site(AncestorBuilder *self, PyObject *args, PyObject *kwds)
             &site_id, &age, &PyArray_Type, &genotypes)) {
         goto out;
     }
-    genotypes_array = (PyArrayObject *) PyArray_FROM_OTF(genotypes, NPY_UINT8,
+    genotypes_array = (PyArrayObject *) PyArray_FROM_OTF(genotypes, NPY_INT8,
             NPY_ARRAY_IN_ARRAY);
     if (genotypes_array == NULL) {
         goto out;
@@ -188,7 +188,7 @@ AncestorBuilder_make_ancestor(AncestorBuilder *self, PyObject *args, PyObject *k
         PyErr_SetString(PyExc_ValueError, "num_focal_sites must > 0 and <= num_sites");
         goto fail;
     }
-    ancestor_array = (PyArrayObject *) PyArray_FROM_OTF(ancestor, NPY_UINT8,
+    ancestor_array = (PyArrayObject *) PyArray_FROM_OTF(ancestor, NPY_INT8,
             NPY_ARRAY_INOUT_ARRAY);
     if (ancestor_array == NULL) {
         goto fail;
@@ -611,7 +611,7 @@ TreeSequenceBuilder_add_mutations(TreeSequenceBuilder *self, PyObject *args, PyO
     num_mutations = shape[0];
 
     /* derived_state */
-    derived_state_array = (PyArrayObject *) PyArray_FROM_OTF(derived_state, NPY_UINT8,
+    derived_state_array = (PyArrayObject *) PyArray_FROM_OTF(derived_state, NPY_INT8,
             NPY_ARRAY_IN_ARRAY);
     if (derived_state_array == NULL) {
         goto out;
@@ -1308,7 +1308,7 @@ AncestorMatcher_find_path(AncestorMatcher *self, PyObject *args, PyObject *kwds)
                 &haplotype, &start, &end, &PyArray_Type, &match)) {
         goto out;
     }
-    haplotype_array = (PyArrayObject *) PyArray_FROM_OTF(haplotype, NPY_UINT8,
+    haplotype_array = (PyArrayObject *) PyArray_FROM_OTF(haplotype, NPY_INT8,
             NPY_ARRAY_IN_ARRAY);
     if (haplotype_array == NULL) {
         goto out;
@@ -1323,7 +1323,7 @@ AncestorMatcher_find_path(AncestorMatcher *self, PyObject *args, PyObject *kwds)
         goto out;
     }
 
-    match_array = (PyArrayObject *) PyArray_FROM_OTF(match, NPY_UINT8,
+    match_array = (PyArrayObject *) PyArray_FROM_OTF(match, NPY_INT8,
             NPY_ARRAY_INOUT_ARRAY);
     if (match_array == NULL) {
         goto out;

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -30,7 +30,6 @@ import tskit
 import numpy as np
 
 import tsinfer
-import tsinfer.constants as constants
 
 
 def get_smc_simulation(n, L=1, recombination_rate=0, seed=1):
@@ -300,8 +299,7 @@ class TestGetAncestralHaplotypes(unittest.TestCase):
         """
         Simple implementation using tree traversals.
         """
-        A = np.zeros((ts.num_nodes, ts.num_sites), dtype=np.uint8)
-        A[:] = constants.UNKNOWN_ALLELE
+        A = np.full((ts.num_nodes, ts.num_sites), tskit.MISSING_DATA, dtype=np.int8)
         for t in ts.trees():
             for site in t.sites():
                 for u in t.nodes():
@@ -338,7 +336,7 @@ class TestGetAncestralHaplotypes(unittest.TestCase):
                 self.assertTrue(np.all(A[above, site.id] == 0))
                 outside = np.array(list(
                     set(range(ts.num_nodes)) - set(tree.nodes())), dtype=int)
-                self.assertTrue(np.all(A[outside, site.id] == constants.UNKNOWN_ALLELE))
+                self.assertTrue(np.all(A[outside, site.id] == tskit.MISSING_DATA))
 
     def test_single_tree(self):
         ts = msprime.simulate(5, mutation_rate=10, random_seed=234)
@@ -423,9 +421,9 @@ class TestGetAncestorDescriptors(unittest.TestCase):
         self.assertTrue(np.all(ancestors[0, :] == 0))
         for a, s, e, focal in zip(ancestors[1:], start[1:], end[1:], focal_sites[1:]):
             self.assertTrue(0 <= s < e <= m)
-            self.assertTrue(np.all(a[:s] == constants.UNKNOWN_ALLELE))
-            self.assertTrue(np.all(a[e:] == constants.UNKNOWN_ALLELE))
-            self.assertTrue(np.all(a[s:e] != constants.UNKNOWN_ALLELE))
+            self.assertTrue(np.all(a[:s] == tskit.MISSING_DATA))
+            self.assertTrue(np.all(a[e:] == tskit.MISSING_DATA))
+            self.assertTrue(np.all(a[s:e] != tskit.MISSING_DATA))
             for site in focal:
                 self.assertEqual(a[site], 1)
 
@@ -906,7 +904,7 @@ class TestNodeSpan(unittest.TestCase):
         np.random.seed(10)
         num_sites = 40
         num_samples = 8
-        G = np.random.randint(2, size=(num_sites, num_samples)).astype(np.uint8)
+        G = np.random.randint(2, size=(num_sites, num_samples)).astype(np.int8)
         with tsinfer.SampleData() as sample_data:
             for j in range(num_sites):
                 sample_data.add_site(j, G[j])
@@ -978,7 +976,7 @@ class TestMeanSampleAncestry(unittest.TestCase):
 
     def get_random_data_example(self, num_sites, num_samples, seed=100):
         np.random.seed(seed)
-        G = np.random.randint(2, size=(num_sites, num_samples)).astype(np.uint8)
+        G = np.random.randint(2, size=(num_sites, num_samples)).astype(np.int8)
         with tsinfer.SampleData() as sample_data:
             for j in range(num_sites):
                 sample_data.add_site(j, G[j])
@@ -1126,7 +1124,7 @@ class TestSnipCentromere(unittest.TestCase):
 
     def get_random_data_example(self, position, num_samples, seed=100):
         np.random.seed(seed)
-        G = np.random.randint(2, size=(position.shape[0], num_samples)).astype(np.uint8)
+        G = np.random.randint(2, size=(position.shape[0], num_samples)).astype(np.int8)
         with tsinfer.SampleData() as sample_data:
             for j, x in enumerate(position):
                 sample_data.add_site(x, G[j])

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -693,7 +693,7 @@ class TestBuildAncestors(unittest.TestCase):
             self.assertEqual(a.shape[0], end[j] - start[j])
             h = np.zeros(ancestor_data.num_sites, dtype=np.uint8)
             h[start[j]: end[j]] = a
-            self.assertTrue(np.all(h[start[j]:end[j]] != tsinfer.UNKNOWN_ALLELE))
+            self.assertTrue(np.all(h[start[j]:end[j]] != tskit.MISSING_DATA))
             self.assertTrue(np.all(h[focal_sites[j]] == 1))
             used_sites.extend(focal_sites[j])
             self.assertGreater(age[j], 0)

--- a/tsinfer/constants.py
+++ b/tsinfer/constants.py
@@ -17,10 +17,8 @@
 # along with tsinfer.  If not, see <http://www.gnu.org/licenses/>.
 #
 """
-Collection of constants used in tsinfer.
+Collection of constants used in tsinfer. We also make use of constants defined in tskit.
 """
-
-UNKNOWN_ALLELE = 255
 
 C_ENGINE = "C"
 PY_ENGINE = "P"

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -17,7 +17,7 @@
 # along with tsinfer.  If not, see <http://www.gnu.org/licenses/>.
 #
 """
-Manage tsinfer's various HDF5 file formats.
+Manage tsinfer's various file formats.
 """
 import collections.abc as abc
 import datetime
@@ -425,15 +425,15 @@ class DataContainer(object):
 
     def _check_build_mode(self):
         if self._mode != self.BUILD_MODE:
-            raise ValueError("Invalid opertion: must be in build mode")
+            raise ValueError("Invalid operation: must be in build mode")
 
     def _check_edit_mode(self):
         if self._mode != self.EDIT_MODE:
-            raise ValueError("Invalid opertion: must be in edit mode")
+            raise ValueError("Invalid operation: must be in edit mode")
 
     def _check_write_modes(self):
         if self._mode not in (self.EDIT_MODE, self.BUILD_MODE):
-            raise ValueError("Invalid opertion: must be in edit or build mode")
+            raise ValueError("Invalid operation: must be in edit or build mode")
 
     @property
     def file_size(self):
@@ -753,7 +753,7 @@ class SampleData(DataContainer):
             dtype=np.float64)
         sites_group.create_dataset(
             "genotypes", shape=(0, 0), chunks=(self._chunk_size, self._chunk_size),
-            compressor=self._compressor, dtype=np.uint8)
+            compressor=self._compressor, dtype=np.int8)
         sites_group.create_dataset(
             "inference", shape=(0,), chunks=chunks, compressor=self._compressor,
             dtype=np.uint8)
@@ -1076,7 +1076,7 @@ class SampleData(DataContainer):
             genotypes at this site. The array of genotypes corresponds to the
             observed alleles for each sample, represented by indexes into the
             alleles array. This input is converted to a numpy array with
-            dtype ``np.uint8``; therefore, for maximum efficiency ensure
+            dtype ``np.int8``; therefore, for maximum efficiency ensure
             that the input array is also of this type.
         :param list(str) alleles: A list of strings defining the alleles at this
             site. The zero'th element of this list is the **ancestral state**
@@ -1099,7 +1099,7 @@ class SampleData(DataContainer):
         :return: The ID of the newly added site.
         :rtype: int
         """
-        genotypes = np.array(genotypes, dtype=np.uint8, copy=False)
+        genotypes = tskit.util.safe_np_int_cast(genotypes, dtype=np.int8)
         self._check_build_mode()
         if self._build_state == self.ADDING_POPULATIONS:
             if genotypes.shape[0] == 0:
@@ -1239,7 +1239,7 @@ class SampleData(DataContainer):
         if samples is None:
             samples = np.arange(self.num_samples)
         else:
-            samples = np.array(samples, copy=False)
+            samples = tskit.util.safe_np_int_cast(samples, dtype=np.int32)
             if np.any(samples[:-1] >= samples[1:]):
                 raise ValueError("sample indexes must be in increasing order.")
             if samples.shape[0] > 0 and samples[-1] >= self.num_samples:
@@ -1336,7 +1336,7 @@ class AncestorData(DataContainer):
             dtype="array:i4", compressor=self._compressor)
         self.data.create_dataset(
             "ancestors/haplotype", shape=(0,), chunks=chunks,
-            dtype="array:u1", compressor=self._compressor)
+            dtype="array:i1", compressor=self._compressor)
 
         self.item_writer = BufferedItemWriter({
             "start": self.ancestors_start,
@@ -1449,12 +1449,12 @@ class AncestorData(DataContainer):
     def add_ancestor(self, start, end, age, focal_sites, haplotype):
         """
         Adds an ancestor with the specified haplotype, with ancestral material
-        over the interval [start:end], that is associated with the specfied age
+        over the interval [start:end], that is associated with the specified age
         and has new mutations at the specified list of focal sites.
         """
         self._check_build_mode()
-        haplotype = np.array(haplotype, dtype=np.uint8)
-        focal_sites = np.array(focal_sites, dtype=np.int32)
+        haplotype = tskit.util.safe_np_int_cast(haplotype, dtype=np.int8, copy=True)
+        focal_sites = tskit.util.safe_np_int_cast(focal_sites, dtype=np.int32, copy=True)
         if start < 0:
             raise ValueError("Start must be >= 0")
         if end > self._num_sites:

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -344,7 +344,7 @@ class AncestorsGenerator(object):
         logger.info("Finished adding sites")
 
     def _run_synchronous(self, progress):
-        a = np.zeros(self.num_sites, dtype=np.uint8)
+        a = np.zeros(self.num_sites, dtype=np.int8)
         for age, focal_sites in self.descriptors:
             before = time.perf_counter()
             s, e = self.ancestor_builder.make_ancestor(focal_sites, a)
@@ -385,7 +385,7 @@ class AncestorsGenerator(object):
             logger.debug("Drained {} ancestors from add queue".format(num_drained))
 
         def build_worker(thread_index):
-            a = np.zeros(self.num_sites, dtype=np.uint8)
+            a = np.zeros(self.num_sites, dtype=np.int8)
             while True:
                 work = build_queue.get()
                 if work is None:
@@ -428,7 +428,7 @@ class AncestorsGenerator(object):
         if self.num_ancestors > 0:
             logger.info("Starting build for {} ancestors".format(self.num_ancestors))
             progress = self.progress_monitor.get("ga_generate", self.num_ancestors)
-            a = np.zeros(self.num_sites, dtype=np.uint8)
+            a = np.zeros(self.num_sites, dtype=np.int8)
             root_age = max(self.age_to_epoch.keys()) + 1
             ultimate_ancestor_age = root_age + 1
             # Add the ultimate ancestor. This is an awkward hack really; we don't
@@ -487,7 +487,7 @@ class Matcher(object):
 
         # Allocate the matchers and statistics arrays.
         num_threads = max(1, self.num_threads)
-        self.match = [np.zeros(self.num_sites, np.uint8) for _ in range(num_threads)]
+        self.match = [np.zeros(self.num_sites, np.int8) for _ in range(num_threads)]
         self.results = ResultBuffer()
         self.mean_traceback_size = np.zeros(num_threads)
         self.num_matches = np.zeros(num_threads)
@@ -877,7 +877,7 @@ class AncestorMatcher(Matcher):
         a = next(self.ancestors, None)
         self.num_epochs = 0
         if a is not None:
-            assert np.array_equal(a.haplotype, np.zeros(self.num_sites, dtype=np.uint8))
+            assert np.array_equal(a.haplotype, np.zeros(self.num_sites, dtype=np.int8))
             # Create a list of all ID ranges in each epoch.
             breaks = np.where(self.epoch[1:] != self.epoch[:-1])[0]
             start = np.hstack([[0], breaks + 1])
@@ -894,7 +894,7 @@ class AncestorMatcher(Matcher):
         ])
 
     def __ancestor_find_path(self, ancestor, thread_index=0):
-        haplotype = np.zeros(self.num_sites, dtype=np.uint8) + constants.UNKNOWN_ALLELE
+        haplotype = np.full(self.num_sites, tskit.MISSING_DATA, dtype=np.int8)
         focal_sites = ancestor.focal_sites
         start = ancestor.start
         end = ancestor.end
@@ -1154,7 +1154,7 @@ class ResultBuffer(object):
 
     def set_mutations(self, node_id, site, derived_state=None):
         if derived_state is None:
-            derived_state = np.ones(site.shape[0], dtype=np.uint8)
+            derived_state = np.ones(site.shape[0], dtype=np.int8)
         with self.lock:
             self.mutations[node_id] = site, derived_state
 


### PR DESCRIPTION
This also switches the C code to using signed ints for genotypes. Guess that's OK. It will fail tests unless it is used with a tskit version that includes https://github.com/tskit-dev/tskit/pull/267 which exports tskit.MISSING_DATA, which I'm now using as a replacement for tsinfer.constants.UNKNOWN_ALLELE (I think this makes sense)