### PR TITLE
Set keep_unary on simplify, and document (including path compression docs)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -42,8 +42,7 @@ Running inference
 
 .. autofunction:: tsinfer.match_samples
 
-.. todo::
-    1. Add documentation for path compression here.
+.. autofunction:: tsinfer.augment_ancestors
 
 ++++++++++
 Exceptions

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -197,7 +197,7 @@ The final phase of a ``tsinfer`` inference consists of a number steps:
    for our sample haplotypes through the ancestors. Each copying path
    corresponds to a set of tree sequence edges in precisely the same
    way as for ancestors, and the path compression algorithm can be equally
-   applied here. 
+   applied here.
 
 
 2. As we only use a subset of the available sites for inference
@@ -213,7 +213,7 @@ The final phase of a ``tsinfer`` inference consists of a number steps:
    may be clades of ancestral state samples which would allow us
    to encode the data with fewer back mutations.**
 
-3. Remove ancestral paths that do not lead to any of the samples by 
+3. Remove ancestral paths that do not lead to any of the samples by
    `simplifying
    <https://tskit.readthedocs.io/en/latest/python-api.html#tskit.TreeSequence.simplify>`_
    the final tree sequence. When simplifying, we keep non-branching ("unary")

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -198,13 +198,18 @@ The final phase of a ``tsinfer`` inference consists of a number steps:
    may be clades of ancestral state samples which would allow us
    to encode the data with fewer back mutations.**
 
-3. Reduce the resulting tree sequence to a canonical form by
-   `simplifying it
-   <https://tskit.readthedocs.io/en/latest/python-api.html#tskit.TreeSequence.simplify>`_.
+3. Remove ancestral paths that do not lead to any of the samples by 
+   `simplifying
+   <https://tskit.readthedocs.io/en/latest/python-api.html#tskit.TreeSequence.simplify>`_
+   the final tree sequence. When simplifying, we keep non-branching ("unary")
+   nodes, as they indicate ancestors which we have actively inferred, and
+   for technical reasons keeping unary ancestors can also lead to better
+   compression. Note that this means that not every internal node in the
+   inferred tree sequence will correspond to a coalescent event.
 
 .. todo::
     1. Describe path compression here and above in the ancestors
        section
-    2. Describe the structure of the outpt tree sequences; how the
+    2. Describe the structure of the output tree sequences; how the
        nodes are mapped, what the time values mean, etc.
 

--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -161,6 +161,19 @@ given time, and an ancestor can copy from any older ancestor. For each
 ancestor, we find a path through older ancestors that minimises the
 number of recombination events.
 
+As well as minimising recombination events by finding the best path, we can also
+minimise events by looking for *shared recombination breakpoints*. A shared
+breakpoint exists if a set of children share a breakpoint in the same position,
+and they also have identical parents to the left of the breakpoint and identical
+parents to the right of the breakpoint. Rather than supposing that these
+children experienced multiple identical recombination events in parallel, we can
+reduce the number of ancestral recombination events by postulating a "synthetic
+ancestor" with this breakpoint, existing at a slightly older point
+in time, from whom all the children are descended at this genomic position. We
+call the algorithm used to implement this addition to the ancestral copying
+paths, "path compression".
+
+
 .. todo:: Schematic of the ancestors copying process.
 
 The copying path for each ancestor then describes its ancestry at every
@@ -183,7 +196,9 @@ The final phase of a ``tsinfer`` inference consists of a number steps:
 1. The first (and usually most time-consuming) is to find copying paths
    for our sample haplotypes through the ancestors. Each copying path
    corresponds to a set of tree sequence edges in precisely the same
-   way as for ancestors.
+   way as for ancestors, and the path compression algorithm can be equally
+   applied here. 
+
 
 2. As we only use a subset of the available sites for inference
    (excluding by default any sites that are fixed or singletons)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@
 Installation
 ############
 
-Python 3.3 or newer is required for ``tsinfer``. Any Unix-like platform should
+Python 3.5 or newer is required for ``tsinfer``. Any Unix-like platform should
 work (``tsinfer`` is tested on Linux, OS X, and Windows).
 
 Please use ``pip`` to install,

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,8 +4,8 @@
 Installation
 ############
 
-Python 3.3 or newer is required for ``tsinfer``. Any Unix-like platform should work
-(``tsinfer`` is tested on Linux and OSX).
+Python 3.3 or newer is required for ``tsinfer``. Any Unix-like platform should
+work (``tsinfer`` is tested on Linux, OS X, and Windows).
 
 Please use ``pip`` to install,
 e.g.::
@@ -32,8 +32,6 @@ first using `venv <https://docs.python.org/3/library/venv.html>`_::
     $ source tsinfer-venv/bin/activate
     (tsinfer-venv) $ pip install tsinfer
     (tsinfer-venv) $ tsinfer --help
-
-.. _sec_installation_installation_problems:
 
 ****************
 Potential issues

--- a/evaluation.py
+++ b/evaluation.py
@@ -373,9 +373,13 @@ def edge_plot(ts, filename):
     for tree in ts.trees():
         left, right = tree.interval
         for u in tree.nodes():
-            for c in tree.children(u):
-                lines.append([(left, c), (right, c)])
-                colours.append(pallete[unrank(tree.samples(c), n)])
+            children = tree.children(u)
+            # Don't bother plotting unary nodes, which will all have the same
+            # samples under them as their next non-unary descendant
+            if len(children) > 1:
+                for c in children:
+                    lines.append([(left, c), (right, c)])
+                    colours.append(pallete[unrank(tree.samples(c), n)])
 
     lc = mc.LineCollection(lines, linewidths=2, colors=colours)
     fig, ax = plt.subplots()

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "tqdm",
         "humanize",
         "daiquiri",
-        "tskit>=0.2.0a3",
+        "tskit>=0.2.1",
         "numcodecs>=0.6",
         "zarr>=2.2",
         "lmdb",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "tqdm",
         "humanize",
         "daiquiri",
-        "tskit",
+        "tskit>=0.2.0a3",
         "numcodecs>=0.6",
         "zarr>=2.2",
         "lmdb",

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -311,7 +311,7 @@ class TestZeroInferenceSites(unittest.TestCase):
     Tests for the degenerate case in which we have no inference sites.
     """
     def verify(self, genotypes):
-        genotypes = np.array(genotypes, dtype=np.uint8)
+        genotypes = np.array(genotypes, dtype=np.int8)
         m = genotypes.shape[0]
         with tsinfer.SampleData(sequence_length=m + 1) as sample_data:
             for j in range(m):
@@ -628,8 +628,7 @@ class TestGeneratedAncestors(unittest.TestCase):
             tsinfer.check_ancestors_ts(ancestors_ts)
             self.assertEqual(ancestor_data.num_sites, ancestors_ts.num_sites)
             self.assertEqual(ancestor_data.num_ancestors, ancestors_ts.num_samples)
-            self.assertTrue(np.array_equal(
-                ancestors_ts.genotype_matrix(impute_missing_data=True), A))
+            self.assertTrue(np.array_equal(ancestors_ts.genotype_matrix(), A))
             inferred_ts = tsinfer.match_samples(
                 sample_data, ancestors_ts, engine=engine)
             self.assertTrue(np.array_equal(
@@ -1229,6 +1228,14 @@ class TestSimplify(unittest.TestCase):
         self.assertEqual(
             list(ts2.samples()),
             list(range(ts2.num_nodes - n, ts2.num_nodes)))
+
+        # Check that we're calling simplify with the correct arguments.
+        ts2 = tsinfer.infer(sd, simplify=False).simplify(keep_unary=True)
+        t1 = ts1.dump_tables()
+        t2 = ts2.dump_tables()
+        t1.provenances.clear()
+        t2.provenances.clear()
+        self.assertEqual(t1, t2)
 
     def test_single_tree(self):
         ts = msprime.simulate(5, random_seed=1, mutation_rate=2)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -311,7 +311,7 @@ class TestZeroInferenceSites(unittest.TestCase):
     Tests for the degenerate case in which we have no inference sites.
     """
     def verify(self, genotypes):
-        genotypes = np.array(genotypes, dtype=np.int8)
+        genotypes = np.array(genotypes, dtype=np.uint8)
         m = genotypes.shape[0]
         with tsinfer.SampleData(sequence_length=m + 1) as sample_data:
             for j in range(m):
@@ -610,13 +610,13 @@ class TestGeneratedAncestors(unittest.TestCase):
         with tsinfer.SampleData(sequence_length=ts.sequence_length) as sample_data:
             for v in ts.variants():
                 sample_data.add_site(v.position, v.genotypes, v.alleles)
-
         ancestor_data = tsinfer.AncestorData(sample_data)
         tsinfer.build_simulated_ancestors(sample_data, ancestor_data, ts)
         ancestor_data.finalise()
 
-        A = np.zeros(
-            (ancestor_data.num_sites, ancestor_data.num_ancestors), dtype=np.uint8)
+        A = np.full(
+            (ancestor_data.num_sites, ancestor_data.num_ancestors),
+            tskit.MISSING_DATA, dtype=np.int8)
         start = ancestor_data.ancestors_start[:]
         end = ancestor_data.ancestors_end[:]
         ancestors = ancestor_data.ancestors_haplotype[:]

--- a/tsinfer/eval_util.py
+++ b/tsinfer/eval_util.py
@@ -705,6 +705,8 @@ def run_perfect_inference(
         num_threads=num_threads, extended_checks=extended_checks,
         progress_monitor=progress_monitor,
         stabilise_node_ordering=time_chunking and not path_compression)
+    # to compare against the original, we need to remove unary nodes from the inferred TS
+    inferred_ts = inferred_ts.simplify(keep_unary=False, filter_sites=False)
     return ts, inferred_ts
 
 

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -250,8 +250,8 @@ def augment_ancestors(
         sample_data, ancestors_ts, indexes, num_threads=0, path_compression=True,
         extended_checks=False, engine=constants.C_ENGINE, progress_monitor=None):
     """
-    augment_ancestors(sample_data, ancestors_ts, indexes, num_threads=0,
-    path_compression=True)
+    augment_ancestors(sample_data, ancestors_ts, indexes, num_threads=0,\
+        path_compression=True)
 
     Runs the sample matching :ref:`algorithm <sec_inference_match_samples>`
     on the specified :class:`SampleData` instance and ancestors tree sequence,
@@ -290,7 +290,7 @@ def match_samples(
         extended_checks=False, stabilise_node_ordering=False, engine=constants.C_ENGINE,
         progress_monitor=None):
     """
-    match_samples(sample_data, ancestors_ts, num_threads=0, path_compression=True,
+    match_samples(sample_data, ancestors_ts, num_threads=0, path_compression=True,\
         simplify=True)
 
     Runs the sample matching :ref:`algorithm <sec_inference_match_samples>`


### PR DESCRIPTION
We should also switch `simplify` in these cases to set `keep_unary=True`, and document accordingly.