### PR TITLE
Change "age" references to "time"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,45 @@
 ********************
+[0.1.5] - 2019-09-25
+********************
+
+
+**Breaking changes**:
+
+- Bumped SampleData file format version to 2.0, then to 3.0 as a result of the additions
+  below. Older SampleData files will not be readable and must be regenerated.
+
+- Users can specify variant ages, via ``sample_data.add_sites(... , time=user_time)``.
+  If not ``None``, this overrides the default time position of an ancestor, otherwise
+  ancestors are ordered in time by using the frequency of the derived variant (#143).
+  This addition bumped the file format to 2.0
+
+- Change "age" to "time" to match tskit/msprime notation, and to avoid confusion
+  with the age since birth of an individual (#149). Together with the 2 changes below,
+  this addition bumped the file format to 3.0.
+
+- Add the ability to record user-specified times for individuals, and therefore
+  the samples contained in them (currently ignored during inference). Times are
+  added using ``sample_data.add_individual(... , time=user_time)`` (#190). Together
+  with the changes above and below, this addition bumped the file format to 3.0.
+
+- Change ``tsinfer.UNKNOWN_ALLELE`` to ``tskit.MISSING_DATA`` for marking unknown regions
+  of ancestral haplotypes (#188) . This also involves changing the allele storage to a
+  signed int from ``np.uint8`` which matches the tskit v0.2 format for allele storage 
+  (see https://github.com/tskit-dev/tskit/issues/144). Together with the 2 changes above,
+  this addition bumped the file format to 3.0.
+
+**New features**:
+
+- Map non-inference sites onto the tree by using the built-in tskit
+  ``map_mutatations`` method. With further work, this should allow triallelic sites
+  to be mapped (#185)
+  
+- The default tree sequence returned after inference when ``simplify=True`` retains
+  unary nodes (i.e. simplify is done with ``keep_unary=True``. This tends to result
+  in better compression.
+
+
+********************
 [0.1.4] - 2018-12-12
 ********************
 

--- a/_tsinfermodule.c
+++ b/_tsinfermodule.c
@@ -108,10 +108,10 @@ static PyObject *
 AncestorBuilder_add_site(AncestorBuilder *self, PyObject *args, PyObject *kwds)
 {
     int err;
-    static char *kwlist[] = {"site_id", "age", "genotypes", NULL};
+    static char *kwlist[] = {"site_id", "time", "genotypes", NULL};
     PyObject *ret = NULL;
     int site_id;
-    double age;
+    double time;
     PyObject *genotypes = NULL;
     PyArrayObject *genotypes_array = NULL;
     npy_intp *shape;
@@ -120,7 +120,7 @@ AncestorBuilder_add_site(AncestorBuilder *self, PyObject *args, PyObject *kwds)
         goto out;
     }
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "idO!", kwlist,
-            &site_id, &age, &PyArray_Type, &genotypes)) {
+            &site_id, &time, &PyArray_Type, &genotypes)) {
         goto out;
     }
     genotypes_array = (PyArrayObject *) PyArray_FROM_OTF(genotypes, NPY_INT8,
@@ -138,7 +138,7 @@ AncestorBuilder_add_site(AncestorBuilder *self, PyObject *args, PyObject *kwds)
         goto out;
     }
     Py_BEGIN_ALLOW_THREADS
-    err = ancestor_builder_add_site(self->builder, (site_id_t) site_id, age,
+    err = ancestor_builder_add_site(self->builder, (site_id_t) site_id, time,
             (allele_t *) PyArray_DATA(genotypes_array));
     Py_END_ALLOW_THREADS
     if (err != 0) {
@@ -255,7 +255,7 @@ AncestorBuilder_ancestor_descriptors(AncestorBuilder *self)
         }
         memcpy(PyArray_DATA(site_array), descriptor->focal_sites,
                 descriptor->num_focal_sites * sizeof(site_id_t));
-        py_descriptor = Py_BuildValue("dO", descriptor->age, site_array);
+        py_descriptor = Py_BuildValue("dO", descriptor->time, site_array);
         if (py_descriptor == NULL) {
             Py_DECREF(site_array);
             goto out;

--- a/convert_1kg.py
+++ b/convert_1kg.py
@@ -111,7 +111,7 @@ def variants(vcf_path, show_progress=False):
         except KeyError:
             pass
         if row.num_called == num_diploids and ancestral_state is not None:
-            a = np.zeros(num_samples, dtype=np.uint8)
+            a = np.zeros(num_samples, dtype=np.int8)
             all_alleles = set([ancestral_state])
             # Fill in a with genotypes.
             bases = np.array(row.gt_bases)

--- a/convert_hdf5.py
+++ b/convert_hdf5.py
@@ -13,7 +13,7 @@ def main(infile, outfile):
     sample_data = tsinfer.SampleData.load(infile)
     print(sample_data)
     shape = (sample_data.num_inference_sites, sample_data.num_samples)
-    G = np.empty(shape, dtype=np.uint8)
+    G = np.empty(shape, dtype=np.int8)
     for j, (_, genotypes) in enumerate(sample_data.genotypes(inference_sites=True)):
         G[j] = genotypes
     with h5py.File(outfile, "w") as root:

--- a/lib/tsinfer.h
+++ b/lib/tsinfer.h
@@ -79,7 +79,7 @@ typedef struct _segment_t {
 } segment_t;
 
 typedef struct {
-    double age;
+    double time;
     allele_t *genotypes;
 } site_t;
 
@@ -103,16 +103,16 @@ typedef struct {
 } pattern_map_t;
 
 typedef struct {
-    double age;
+    double time;
     size_t num_focal_sites;
     site_id_t *focal_sites;
 } ancestor_descriptor_t;
 
-/* Maps all ancestors with a specific age to their genotype patterns  */
+/* Maps all ancestors with a specific time to their genotype patterns  */
 typedef struct {
-    double age;
+    double time;
     avl_tree_t pattern_map;
-} age_map_t;
+} time_map_t;
 
 typedef struct {
     size_t num_sites;
@@ -120,7 +120,7 @@ typedef struct {
     size_t num_ancestors;
     int flags;
     site_t *sites;
-    avl_tree_t age_map;
+    avl_tree_t time_map;
     block_allocator_t allocator;
     ancestor_descriptor_t *descriptors;
 } ancestor_builder_t;
@@ -207,7 +207,7 @@ int ancestor_builder_alloc(ancestor_builder_t *self,
 int ancestor_builder_free(ancestor_builder_t *self);
 int ancestor_builder_print_state(ancestor_builder_t *self, FILE *out);
 int ancestor_builder_add_site(ancestor_builder_t *self, site_id_t site,
-        double age, allele_t *genotypes);
+        double time, allele_t *genotypes);
 int ancestor_builder_make_ancestor(ancestor_builder_t *self,
         size_t num_focal_sites, site_id_t *focal_sites,
         site_id_t *start, site_id_t *end, allele_t *haplotype);

--- a/tsinfer/algorithm.py
+++ b/tsinfer/algorithm.py
@@ -635,6 +635,7 @@ class AncestorMatcher(object):
         self.total_memory = 0
 
     def print_state(self):
+        # TODO - don't crash when self.max_likelihood_node or self.traceback == None
         print("Ancestor matcher state")
         print("max_L_node\ttraceback")
         for l in range(self.num_sites):

--- a/tsinfer/eval_util.py
+++ b/tsinfer/eval_util.py
@@ -389,7 +389,7 @@ def build_simulated_ancestors(sample_data, ancestor_data, ts, time_chunking=Fals
         assert np.all(a[e:] == tskit.MISSING_DATA)
         assert all(s <= site < e for site in focal)
         ancestor_data.add_ancestor(
-            start=s, end=e, age=t, focal_sites=np.array(focal, dtype=np.int32),
+            start=s, end=e, time=t, focal_sites=np.array(focal, dtype=np.int32),
             haplotype=a[s:e])
 
 

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -701,7 +701,7 @@ class SampleData(DataContainer):
         compression level and algorithm performance. Default=1024.
     """
     FORMAT_NAME = "tsinfer-sample-data"
-    FORMAT_VERSION = (2, 0)
+    FORMAT_VERSION = (3, 0)
 
     # State machine for handling automatic addition of samples.
     ADDING_POPULATIONS = 0
@@ -1335,7 +1335,7 @@ class AncestorData(DataContainer):
         compression level and algorithm performance. Default=1024.
     """
     FORMAT_NAME = "tsinfer-ancestor-data"
-    FORMAT_VERSION = (2, 0)
+    FORMAT_VERSION = (3, 0)
 
     def __init__(self, sample_data, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
Fixes https://github.com/tskit-dev/tsinfer/issues/149

This also changes the underlying storage name from `sites/age` to `sites/time`, and the name of the equivalent parameter in `SampleData.add_site()`, so it will break code if anyone is specifying the "age" parameter by name not position. But I think @awohns is the only user of this functionality at the moment.

If we want `tsinfer` to be terminologically consistent with `tskit` like this, then this is the time to do it!