### PR TITLE
Switch to (signed) int8 & tskit.MISSING_DATA to mark unknown regions …

### DIFF
--- a/_tsinfermodule.c
+++ b/_tsinfermodule.c
@@ -123,7 +123,7 @@ AncestorBuilder_add_site(AncestorBuilder *self, PyObject *args, PyObject *kwds)
             &site_id, &age, &PyArray_Type, &genotypes)) {
         goto out;
     }
-    genotypes_array = (PyArrayObject *) PyArray_FROM_OTF(genotypes, NPY_UINT8,
+    genotypes_array = (PyArrayObject *) PyArray_FROM_OTF(genotypes, NPY_INT8,
             NPY_ARRAY_IN_ARRAY);
     if (genotypes_array == NULL) {
         goto out;
@@ -188,7 +188,7 @@ AncestorBuilder_make_ancestor(AncestorBuilder *self, PyObject *args, PyObject *k
         PyErr_SetString(PyExc_ValueError, "num_focal_sites must > 0 and <= num_sites");
         goto fail;
     }
-    ancestor_array = (PyArrayObject *) PyArray_FROM_OTF(ancestor, NPY_UINT8,
+    ancestor_array = (PyArrayObject *) PyArray_FROM_OTF(ancestor, NPY_INT8,
             NPY_ARRAY_INOUT_ARRAY);
     if (ancestor_array == NULL) {
         goto fail;
@@ -611,7 +611,7 @@ TreeSequenceBuilder_add_mutations(TreeSequenceBuilder *self, PyObject *args, PyO
     num_mutations = shape[0];
 
     /* derived_state */
-    derived_state_array = (PyArrayObject *) PyArray_FROM_OTF(derived_state, NPY_UINT8,
+    derived_state_array = (PyArrayObject *) PyArray_FROM_OTF(derived_state, NPY_INT8,
             NPY_ARRAY_IN_ARRAY);
     if (derived_state_array == NULL) {
         goto out;
@@ -1308,7 +1308,7 @@ AncestorMatcher_find_path(AncestorMatcher *self, PyObject *args, PyObject *kwds)
                 &haplotype, &start, &end, &PyArray_Type, &match)) {
         goto out;
     }
-    haplotype_array = (PyArrayObject *) PyArray_FROM_OTF(haplotype, NPY_UINT8,
+    haplotype_array = (PyArrayObject *) PyArray_FROM_OTF(haplotype, NPY_INT8,
             NPY_ARRAY_IN_ARRAY);
     if (haplotype_array == NULL) {
         goto out;
@@ -1323,7 +1323,7 @@ AncestorMatcher_find_path(AncestorMatcher *self, PyObject *args, PyObject *kwds)
         goto out;
     }
 
-    match_array = (PyArrayObject *) PyArray_FROM_OTF(match, NPY_UINT8,
+    match_array = (PyArrayObject *) PyArray_FROM_OTF(match, NPY_INT8,
             NPY_ARRAY_INOUT_ARRAY);
     if (match_array == NULL) {
         goto out;

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -30,7 +30,6 @@ import tskit
 import numpy as np
 
 import tsinfer
-import tsinfer.constants as constants
 
 
 def get_smc_simulation(n, L=1, recombination_rate=0, seed=1):
@@ -300,8 +299,7 @@ class TestGetAncestralHaplotypes(unittest.TestCase):
         """
         Simple implementation using tree traversals.
         """
-        A = np.zeros((ts.num_nodes, ts.num_sites), dtype=np.uint8)
-        A[:] = constants.UNKNOWN_ALLELE
+        A = np.full((ts.num_nodes, ts.num_sites), tskit.MISSING_DATA, dtype=np.int8)
         for t in ts.trees():
             for site in t.sites():
                 for u in t.nodes():
@@ -338,7 +336,7 @@ class TestGetAncestralHaplotypes(unittest.TestCase):
                 self.assertTrue(np.all(A[above, site.id] == 0))
                 outside = np.array(list(
                     set(range(ts.num_nodes)) - set(tree.nodes())), dtype=int)
-                self.assertTrue(np.all(A[outside, site.id] == constants.UNKNOWN_ALLELE))
+                self.assertTrue(np.all(A[outside, site.id] == tskit.MISSING_DATA))
 
     def test_single_tree(self):
         ts = msprime.simulate(5, mutation_rate=10, random_seed=234)
@@ -423,9 +421,9 @@ class TestGetAncestorDescriptors(unittest.TestCase):
         self.assertTrue(np.all(ancestors[0, :] == 0))
         for a, s, e, focal in zip(ancestors[1:], start[1:], end[1:], focal_sites[1:]):
             self.assertTrue(0 <= s < e <= m)
-            self.assertTrue(np.all(a[:s] == constants.UNKNOWN_ALLELE))
-            self.assertTrue(np.all(a[e:] == constants.UNKNOWN_ALLELE))
-            self.assertTrue(np.all(a[s:e] != constants.UNKNOWN_ALLELE))
+            self.assertTrue(np.all(a[:s] == tskit.MISSING_DATA))
+            self.assertTrue(np.all(a[e:] == tskit.MISSING_DATA))
+            self.assertTrue(np.all(a[s:e] != tskit.MISSING_DATA))
             for site in focal:
                 self.assertEqual(a[site], 1)
 
@@ -906,7 +904,7 @@ class TestNodeSpan(unittest.TestCase):
         np.random.seed(10)
         num_sites = 40
         num_samples = 8
-        G = np.random.randint(2, size=(num_sites, num_samples)).astype(np.uint8)
+        G = np.random.randint(2, size=(num_sites, num_samples)).astype(np.int8)
         with tsinfer.SampleData() as sample_data:
             for j in range(num_sites):
                 sample_data.add_site(j, G[j])
@@ -978,7 +976,7 @@ class TestMeanSampleAncestry(unittest.TestCase):
 
     def get_random_data_example(self, num_sites, num_samples, seed=100):
         np.random.seed(seed)
-        G = np.random.randint(2, size=(num_sites, num_samples)).astype(np.uint8)
+        G = np.random.randint(2, size=(num_sites, num_samples)).astype(np.int8)
         with tsinfer.SampleData() as sample_data:
             for j in range(num_sites):
                 sample_data.add_site(j, G[j])
@@ -1126,7 +1124,7 @@ class TestSnipCentromere(unittest.TestCase):
 
     def get_random_data_example(self, position, num_samples, seed=100):
         np.random.seed(seed)
-        G = np.random.randint(2, size=(position.shape[0], num_samples)).astype(np.uint8)
+        G = np.random.randint(2, size=(position.shape[0], num_samples)).astype(np.int8)
         with tsinfer.SampleData() as sample_data:
             for j, x in enumerate(position):
                 sample_data.add_site(x, G[j])

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -32,6 +32,7 @@ import msprime
 import numcodecs
 import numcodecs.blosc as blosc
 import zarr
+import tskit
 
 import tsinfer
 import tsinfer.formats as formats
@@ -96,7 +97,7 @@ class TestSampleData(unittest.TestCase, DataContainerMixin):
         self.assertEqual(input_file.num_samples, ts.num_samples)
         self.assertEqual(input_file.sequence_length, ts.sequence_length)
         self.assertEqual(input_file.num_sites, ts.num_sites)
-        self.assertEqual(input_file.sites_genotypes.dtype, np.uint8)
+        self.assertEqual(input_file.sites_genotypes.dtype, np.int8)
         self.assertEqual(input_file.sites_position.dtype, np.float64)
         # Take copies to avoid decompressing the data repeatedly.
         genotypes = input_file.sites_genotypes[:]
@@ -255,14 +256,14 @@ class TestSampleData(unittest.TestCase, DataContainerMixin):
 
     def test_variant_errors(self):
         input_file = formats.SampleData(sequence_length=10)
-        genotypes = np.zeros(2, np.uint8)
+        genotypes = np.zeros(2, np.int8)
         input_file.add_site(0, alleles=["0", "1"], genotypes=genotypes)
         for bad_position in [-1, 10, 100]:
             self.assertRaises(
                 ValueError, input_file.add_site, position=bad_position,
                 alleles=["0", "1"], genotypes=genotypes)
         for bad_genotypes in [[0, 2], [-1, 0], [], [0], [0, 0, 0]]:
-            genotypes = np.array(bad_genotypes, dtype=np.uint8)
+            genotypes = np.array(bad_genotypes, dtype=np.int8)
             self.assertRaises(
                 ValueError, input_file.add_site, position=1,
                 alleles=["0", "1"], genotypes=genotypes)
@@ -811,15 +812,15 @@ class TestAncestorData(unittest.TestCase, DataContainerMixin):
         num_sites = sample_data.num_inference_sites
         ancestors = []
         for j in range(num_ancestors):
-            haplotype = np.zeros(num_sites, dtype=np.uint8) + tsinfer.UNKNOWN_ALLELE
+            haplotype = np.full(num_sites, tskit.MISSING_DATA, dtype=np.int8)
             start = j
             end = max(num_sites - j, start + 1)
             self.assertLess(start, end)
             haplotype[start: end] = 0
             if start + j < end:
                 haplotype[start + j: end] = 1
-            self.assertTrue(np.all(haplotype[:start] == tsinfer.UNKNOWN_ALLELE))
-            self.assertTrue(np.all(haplotype[end:] == tsinfer.UNKNOWN_ALLELE))
+            self.assertTrue(np.all(haplotype[:start] == tskit.MISSING_DATA))
+            self.assertTrue(np.all(haplotype[end:] == tskit.MISSING_DATA))
             focal_sites = np.array([start + k for k in range(j)], dtype=np.int32)
             focal_sites = focal_sites[focal_sites < end]
             haplotype[focal_sites] = 1
@@ -981,26 +982,26 @@ class TestAncestorData(unittest.TestCase, DataContainerMixin):
         self.assertRaises(
             ValueError, ancestor_data.add_ancestor,
             start=0, end=num_sites, age=1, focal_sites=[],
-            haplotype=np.zeros(num_sites + 1, dtype=np.uint8))
+            haplotype=np.zeros(num_sites + 1, dtype=np.int8))
         # Haplotypes must be < 2
         self.assertRaises(
             ValueError, ancestor_data.add_ancestor,
             start=0, end=num_sites, age=1, focal_sites=[],
-            haplotype=np.zeros(num_sites, dtype=np.uint8) + 2)
+            haplotype=np.full(num_sites, 2, dtype=np.int8))
         # focal sites must be within start:end
         self.assertRaises(
             ValueError, ancestor_data.add_ancestor,
             start=1, end=num_sites, age=1, focal_sites=[0],
-            haplotype=np.ones(num_sites - 1, dtype=np.uint8))
+            haplotype=np.ones(num_sites - 1, dtype=np.int8))
         self.assertRaises(
             ValueError, ancestor_data.add_ancestor,
             start=0, end=num_sites - 2, age=1, focal_sites=[num_sites - 1],
-            haplotype=np.ones(num_sites, dtype=np.uint8))
+            haplotype=np.ones(num_sites, dtype=np.int8))
         # focal sites must be set to 1
         self.assertRaises(
             ValueError, ancestor_data.add_ancestor,
             start=0, end=num_sites, age=1, focal_sites=[0],
-            haplotype=np.zeros(num_sites, dtype=np.uint8))
+            haplotype=np.zeros(num_sites, dtype=np.int8))
 
     @unittest.skipIf(sys.platform == "win32",
                      "windows simultaneous file permissions issue")

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -693,7 +693,7 @@ class TestBuildAncestors(unittest.TestCase):
             self.assertEqual(a.shape[0], end[j] - start[j])
             h = np.zeros(ancestor_data.num_sites, dtype=np.uint8)
             h[start[j]: end[j]] = a
-            self.assertTrue(np.all(h[start[j]:end[j]] != tsinfer.UNKNOWN_ALLELE))
+            self.assertTrue(np.all(h[start[j]:end[j]] != tskit.MISSING_DATA))
             self.assertTrue(np.all(h[focal_sites[j]] == 1))
             used_sites.extend(focal_sites[j])
             self.assertGreater(age[j], 0)

--- a/tsinfer/constants.py
+++ b/tsinfer/constants.py
@@ -17,10 +17,8 @@
 # along with tsinfer.  If not, see <http://www.gnu.org/licenses/>.
 #
 """
-Collection of constants used in tsinfer.
+Collection of constants used in tsinfer. We also make use of constants defined in tskit.
 """
-
-UNKNOWN_ALLELE = 255
 
 C_ENGINE = "C"
 PY_ENGINE = "P"

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -362,7 +362,7 @@ class AncestorsGenerator(object):
         logger.info("Finished adding sites")
 
     def _run_synchronous(self, progress):
-        a = np.zeros(self.num_sites, dtype=np.uint8)
+        a = np.zeros(self.num_sites, dtype=np.int8)
         for age, focal_sites in self.descriptors:
             before = time.perf_counter()
             s, e = self.ancestor_builder.make_ancestor(focal_sites, a)
@@ -403,7 +403,7 @@ class AncestorsGenerator(object):
             logger.debug("Drained {} ancestors from add queue".format(num_drained))
 
         def build_worker(thread_index):
-            a = np.zeros(self.num_sites, dtype=np.uint8)
+            a = np.zeros(self.num_sites, dtype=np.int8)
             while True:
                 work = build_queue.get()
                 if work is None:
@@ -446,7 +446,7 @@ class AncestorsGenerator(object):
         if self.num_ancestors > 0:
             logger.info("Starting build for {} ancestors".format(self.num_ancestors))
             progress = self.progress_monitor.get("ga_generate", self.num_ancestors)
-            a = np.zeros(self.num_sites, dtype=np.uint8)
+            a = np.zeros(self.num_sites, dtype=np.int8)
             root_age = max(self.age_to_epoch.keys()) + 1
             ultimate_ancestor_age = root_age + 1
             # Add the ultimate ancestor. This is an awkward hack really; we don't
@@ -505,7 +505,7 @@ class Matcher(object):
 
         # Allocate the matchers and statistics arrays.
         num_threads = max(1, self.num_threads)
-        self.match = [np.zeros(self.num_sites, np.uint8) for _ in range(num_threads)]
+        self.match = [np.zeros(self.num_sites, np.int8) for _ in range(num_threads)]
         self.results = ResultBuffer()
         self.mean_traceback_size = np.zeros(num_threads)
         self.num_matches = np.zeros(num_threads)
@@ -861,7 +861,7 @@ class AncestorMatcher(Matcher):
         a = next(self.ancestors, None)
         self.num_epochs = 0
         if a is not None:
-            assert np.array_equal(a.haplotype, np.zeros(self.num_sites, dtype=np.uint8))
+            assert np.array_equal(a.haplotype, np.zeros(self.num_sites, dtype=np.int8))
             # Create a list of all ID ranges in each epoch.
             breaks = np.where(self.epoch[1:] != self.epoch[:-1])[0]
             start = np.hstack([[0], breaks + 1])
@@ -878,7 +878,7 @@ class AncestorMatcher(Matcher):
         ])
 
     def __ancestor_find_path(self, ancestor, thread_index=0):
-        haplotype = np.zeros(self.num_sites, dtype=np.uint8) + constants.UNKNOWN_ALLELE
+        haplotype = np.full(self.num_sites, tskit.MISSING_DATA, dtype=np.int8)
         focal_sites = ancestor.focal_sites
         start = ancestor.start
         end = ancestor.end
@@ -1140,7 +1140,7 @@ class ResultBuffer(object):
 
     def set_mutations(self, node_id, site, derived_state=None):
         if derived_state is None:
-            derived_state = np.ones(site.shape[0], dtype=np.uint8)
+            derived_state = np.ones(site.shape[0], dtype=np.int8)
         with self.lock:
             self.mutations[node_id] = site, derived_state
 


### PR DESCRIPTION
…of ancestral haplotypes

This should complete the move to tsinfer file format 3.0