### PR TITLE
Allow sites_time to be set

### DIFF
--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -851,6 +851,11 @@ class SampleData(DataContainer):
     def sites_time(self):
         return self.data["sites/time"]
 
+    @sites_time.setter
+    def sites_time(self, value):
+        self._check_edit_mode()
+        self.data["sites/time"][:] = np.array(value, dtype=np.float64, copy=False)
+
     @property
     def sites_alleles(self):
         return self.data["sites/alleles"]


### PR DESCRIPTION
Fixes #145

Also I corrected a bug in `test_update_sites_inference_non_copy_mode()` (note test name slightly changed for consistency with `test_update_sites_time_non_copy_mode`), where we previously tested setting the inference sites with an empty array, that was going to fail even if not in copy mode. I could spin this into a separate PR, but it seems too trivial for that.

Also some code duplication here in e.g. `test_copy_update_sites_inference` and `test_copy_update_sites_time` but it seemed the easiest way to write the tests.