### PR TITLE
Don't close the data if this is not a file

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -130,10 +130,10 @@ class TestSampleData(unittest.TestCase, DataContainerMixin):
 
     def test_defaults_no_path(self):
         ts = self.get_example_ts(10, 10)
-        input_file = formats.SampleData(sequence_length=ts.sequence_length)
-        self.verify_data_round_trip(ts, input_file)
-        for _, array in input_file.arrays():
-            self.assertEqual(array.compressor, None)
+        with formats.SampleData(sequence_length=ts.sequence_length) as sample_data:
+            self.verify_data_round_trip(ts, sample_data)
+            for _, array in sample_data.arrays():
+                self.assertEqual(array.compressor, None)
 
     def test_from_tree_sequence(self):
         ts = self.get_example_ts(10, 10)

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -272,7 +272,7 @@ class DataContainer(object):
     def __exit__(self, *args):
         if self._mode != self.READ_MODE:
             self.finalise()
-        else:
+        elif self.path is not None:
             self.close()
 
     def _open_lmbd_readonly(self):


### PR DESCRIPTION
Ported from #202 : this avoids bombing out with `AttributeError: 'DictStore' object has no attribute 'close'` when using a context manager with path==None.

It mirrors what is already done on [line 389](https://github.com/tskit-dev/tsinfer/blob/19a5204dcdbdb9fa55dcc81ca45412750cef67b8/tsinfer/formats.py#L389)