### PR TITLE
Allow pip install of dev requirements even on non-linux

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -13,9 +13,9 @@ lmdb
 attrs
 # Only needed for the Python implementation.
 sortedcontainers
-# Optional extras for debugging threads
-python-prctl
-numa
+# Optional extras for debugging threads - these modules mainly work on linux
+python-prctl; sys_platform == 'linux'
+numa; sys_platform == 'linux'
 # Needed for building docs.
 sphinx
 sphinx-argparse


### PR DESCRIPTION
Since prctl and numa are optional, and prctl doesn't even work on non-linux systems, only install these on linux