### PR TITLE
Round after norm

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -97,7 +97,7 @@ def generate_samples(ts, error_p):
 def tsinfer_dev(
         n, L, seed, num_threads=1, recombination_rate=1e-8,
         error_rate=0, engine="C", log_level="WARNING",
-        debug=True, progress=False, path_compression=True):
+        precision=None, debug=True, progress=False, path_compression=True):
 
     np.random.seed(seed)
     random.seed(seed)
@@ -135,7 +135,9 @@ def tsinfer_dev(
 
     ancestors_ts = tsinfer.match_ancestors(
         samples, ancestor_data, engine=engine, path_compression=True,
-        extended_checks=False, recombination_rate=rho,
+        extended_checks=False,
+        precision=precision,
+        recombination_rate=rho,
         mutation_rate=mu)
     # print(ancestors_ts.tables)
     # print("ancestors ts")
@@ -160,7 +162,9 @@ def tsinfer_dev(
     ts = tsinfer.match_samples(samples, ancestors_ts,
             recombination_rate=rho, mutation_rate=mu,
             path_compression=False, engine=engine,
-            simplify=False)
+            precision=precision, simplify=False)
+
+    print("num_edges = ", ts.num_edges)
 
     # # print(ts.draw_text())
     # for tree in ts.trees():
@@ -317,7 +321,7 @@ if __name__ == "__main__":
     # for j in range(1, 100):
     #     tsinfer_dev(15, 0.5, seed=j, num_threads=0, engine="P", recombination_rate=1e-8)
     # copy_1kg()
-    tsinfer_dev(18, 0.05, seed=4, num_threads=0, engine="C", recombination_rate=1e-8)
+    tsinfer_dev(118, 0.05, seed=4, num_threads=0, engine="C", recombination_rate=1e-8, precision=0)
 
     # minimise_dev()
 

--- a/lib/ancestor_matcher.c
+++ b/lib/ancestor_matcher.c
@@ -365,7 +365,7 @@ ancestor_matcher_update_site_likelihood_values(ancestor_matcher_t *self,
         if (allelic_state[v] == state) {
             p_e = 1 - (num_alleles - 1) * mu;
         }
-        L[u] = tsk_round(p_t * p_e, self->precision);
+        L[u] = p_t * p_e;
 
         if (L[u] > max_L) {
             max_L = L[u];
@@ -383,7 +383,7 @@ ancestor_matcher_update_site_likelihood_values(ancestor_matcher_t *self,
     /* Renormalise the likelihoods. */
     for (j = 0; j < num_likelihood_nodes; j++) {
         u = L_nodes[j];
-        L[u] /= max_L;
+        L[u] = tsk_round(L[u] / max_L, self->precision);
     }
     ancestor_matcher_unset_allelic_state(self, site, allelic_state);
 out:

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -355,7 +355,7 @@ run_random_data(size_t num_samples, size_t num_sites, int seed, double recombina
     ret = tree_sequence_builder_alloc(&tsb, num_sites, NULL, 1, 1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = ancestor_matcher_alloc(&ancestor_matcher, &tsb, recombination_rates,
-            mutation_rates, 24, TSI_EXTENDED_CHECKS);
+            mutation_rates, 6, TSI_EXTENDED_CHECKS);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
     for (j = 0; j < num_sites; j++) {

--- a/tsinfer/algorithm.py
+++ b/tsinfer/algorithm.py
@@ -693,7 +693,7 @@ class AncestorMatcher(object):
             p_e = mu
             if haplotype_state == self.allelic_state[v]:
                 p_e = 1 - (num_alleles - 1) * mu
-            self.likelihood[u] = round(p_t * p_e, self.precision)
+            self.likelihood[u] = p_t * p_e
 
             if self.likelihood[u] > max_L:
                 max_L = self.likelihood[u]
@@ -705,7 +705,8 @@ class AncestorMatcher(object):
                 "Trying to match non-existent allele with zero mutation rate")
 
         for u in self.likelihood_nodes:
-            self.likelihood[u] /= max_L
+            x = self.likelihood[u] / max_L
+            self.likelihood[u] = round(x, self.precision)
 
         self.max_likelihood_node[site] = max_L_node
         self.unset_allelic_state(site)

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -510,12 +510,11 @@ class Matcher(object):
         self.extended_checks = extended_checks
 
         if precision is None:
-            # For now, default to high precision where round does nothing.
-            precision = 100
+            # TODO Is this a good default? Need to investigate the effects.
+            precision = 2
 
         if recombination_rate is None:
-            # TODO is this a good value? I guess it depends on the default precision
-            # as well. Will need to tune
+            # TODO is this a good value? Will need to tune
             recombination_rate = 1e-8
 
         self.recombination_rate = np.zeros(self.num_sites)


### PR DESCRIPTION
@hyanwong, this sets the default precision to 2 decimal places **after normalisation**. Hopefully this will help a lot with performance.

I guess we can see this as allowing for a maximum of 100 different likelihood values. It might turn out that precision=2 is too drastic as a default, but it'll be good to experiment and see what effect it has.