### PR TITLE
Switch to times as frequencies rather than counts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,8 @@
 
 - The ancestors tree sequence now contains the real alleles and not
   0/1 values as before.
-
+- The time value for a node is now measured on a 0..1 (frequency) scale, not as a count
+  from 1..num_samples
 
 ********************
 [0.1.5] - 2019-09-25

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1239,7 +1239,8 @@ class TestSampleData(unittest.TestCase, DataContainerMixin):
         with formats.SampleData() as data:
             for j in range(4):
                 data.add_site(position=j, alleles=["0", "1"], genotypes=[0, 1, 1, 0])
-        self.assertEqual(list(data.sites_time), [2.0, 2.0, 2.0, 2.0])  # Freq == 2.0
+        # Freq == 0.5
+        self.assertAlmostEqual(list(data.sites_time), [0.5, 0.5, 0.5, 0.5])
 
         with tempfile.TemporaryDirectory(prefix="tsinf_format_test") as tempdir:
             filename = os.path.join(tempdir, "samples.tmp")
@@ -1254,7 +1255,7 @@ class TestSampleData(unittest.TestCase, DataContainerMixin):
                     copy.sites_time = time
                 self.assertFalse(copy.data_equal(data))
                 self.assertEqual(list(copy.sites_time), time)
-                self.assertEqual(list(data.sites_time), [2.0, 2.0, 2.0, 2.0])
+                self.assertAlmostEqual(list(data.sites_time), [0.5, 0.5, 0.5, 0.5])
                 if copy_path is not None:
                     copy.close()
 
@@ -1290,7 +1291,7 @@ class TestSampleData(unittest.TestCase, DataContainerMixin):
         for j in range(4):
             data.add_site(position=j, alleles=["0", "1"], genotypes=[0, 1, 1, 0])
         data.finalise()
-        self.assertEqual(list(data.sites_time), [2.0, 2.0, 2.0, 2.0])
+        self.assertAlmostEqual(list(data.sites_time), [0.5, 0.5, 0.5, 0.5])
         copy = data.copy()
         for bad_shape in [[], np.arange(100, dtype=np.float64), np.zeros((2, 2))]:
             self.assertRaises((ValueError, TypeError), set_value, copy, bad_shape)

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -1381,10 +1381,10 @@ class SampleData(DataContainer):
             number of samples carrying the derived state is greater than
             1 and less than the number of samples.
         :param float time: The time of occurence (pastwards) of the mutation to the
-            derived state at this site. If not specified or None, the count of the
-            derived alleles (i.e., the number of non-zero values in the genotypes) is
-            used instead, with missing values contributing 0.5 to the count. For
-            biallelic sites this count should provide a reasonable estimate
+            derived state at this site. If not specified or None, the frequency of the
+            derived alleles (i.e., the proportion of non-zero values in the genotypes,
+            out of all the non-missing values) is used instead. For
+            biallelic sites this frequency should provide a reasonable estimate
             of the relative time, as used to order ancestral haplotypes during the
             inference process. For sites not used in inference, such as singletons or
             sites with more than two alleles, the value is unused. Defaults to None.
@@ -1438,7 +1438,6 @@ class SampleData(DataContainer):
             )
 
         n_known = np.sum(genotypes != tskit.MISSING_DATA)
-        n_unknown = self.num_samples - n_known
         n_ancestral = np.sum(genotypes == 0)
         n_derived = n_known - n_ancestral
         if n_alleles > 2:
@@ -1458,8 +1457,7 @@ class SampleData(DataContainer):
             if inference:
                 raise ValueError("Cannot use singletons or fixed sites for inference")
         if time is None:
-            time = n_derived  # If n_alleles > 2, then this may not be a sensible approx
-            time += n_unknown / 2.0  # Unknown alleles create intermediate age
+            time = n_derived / n_known  # If n_alleles>2 this may not be sensible
         site_id = self._sites_writer.add(
             position=position,
             genotypes=genotypes,


### PR DESCRIPTION
Fixes #227.

We had expected this to be more involved than simply changing the values from counts to freqs, but this simple change seems to pass all the tests. However, we might want to adjust the delta value for PC_ANCESTOR_INCREMENT (see e.g. https://github.com/tskit-dev/tsinfer/issues/210#issuecomment-551303076) as the current increment of 1.0/65536 will be too large when using a frequency timescale. To replicate the current behaviour we should set it to  `1.0/65536/num_samples`, but that won't fix #210. What would you like me to do @jeromekelleher ?