### PR TITLE
Mark sites whose time is unspecified as -np.inf, implying "use freq"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,8 @@
 
 - The ancestors tree sequence now contains the real alleles and not
   0/1 values as before.
-- The time value for a node is now measured on a 0..1 (frequency) scale, not as a count
-  from 1..num_samples
+- Times for undated sites now use frequencies (0..1), not as counts (1..num_samples),
+  and are now stored as -inf, then calculated on the fly in the variants() iterator.
 
 ********************
 [0.1.5] - 2019-09-25

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1239,10 +1239,10 @@ class TestSampleData(unittest.TestCase, DataContainerMixin):
     def test_copy_update_sites_time(self):
         with formats.SampleData() as data:
             for j in range(4):
-                data.add_site(position=j, alleles=["0", "1"], genotypes=[0, 1, 1, 0])
-        for v in data.variants():
-            self.assertAlmostEqual(v.site.time, data.USE_FREQ_AS_TIME)
-            self.assertAlmostEqual(v.inference_time, 0.5)  # Freq == 0.5
+                data.add_site(
+                    position=j, alleles=["0", "1"], genotypes=[0, 1, 1, 0], time=0.5
+                )
+        self.assertAlmostEqual(list(data.sites_time), [0.5, 0.5, 0.5, 0.5])
 
         with tempfile.TemporaryDirectory(prefix="tsinf_format_test") as tempdir:
             filename = os.path.join(tempdir, "samples.tmp")
@@ -1257,9 +1257,7 @@ class TestSampleData(unittest.TestCase, DataContainerMixin):
                     copy.sites_time = time
                 self.assertFalse(copy.data_equal(data))
                 self.assertEqual(list(copy.sites_time), time)
-                for v in data.variants():
-                    self.assertAlmostEqual(v.site.time, data.USE_FREQ_AS_TIME)
-                    self.assertAlmostEqual(v.inference_time, 0.5)  # Freq == 0.5
+                self.assertAlmostEqual(list(data.sites_time), [0.5, 0.5, 0.5, 0.5])
                 if copy_path is not None:
                     copy.close()
 
@@ -1293,10 +1291,11 @@ class TestSampleData(unittest.TestCase, DataContainerMixin):
 
         data = formats.SampleData()
         for j in range(4):
-            data.add_site(position=j, alleles=["0", "1"], genotypes=[0, 1, 1, 0])
+            data.add_site(
+                position=j, alleles=["0", "1"], genotypes=[0, 1, 1, 0], time=0.5
+            )
         data.finalise()
-        for v in data.variants():
-            self.assertAlmostEqual(v.inference_time, 0.5)
+        self.assertAlmostEqual(list(data.sites_time), [0.5, 0.5, 0.5, 0.5])
         copy = data.copy()
         for bad_shape in [[], np.arange(100, dtype=np.float64), np.zeros((2, 2))]:
             self.assertRaises((ValueError, TypeError), set_value, copy, bad_shape)

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -40,7 +40,6 @@ import tskit
 import tsinfer
 import tsinfer.formats as formats
 import tsinfer.exceptions as exceptions
-import tsinfer.constants as constants
 
 
 class DataContainerMixin(object):
@@ -171,11 +170,9 @@ class TestSampleData(unittest.TestCase, DataContainerMixin):
                     samples_metadata=[json.loads(n.metadata or "{}") for n in nodes],
                 )
         for v in ts.variants():
-            t = None
+            t = np.nan  # default is that a site has no meaningful time
             if len(v.site.mutations) == 1:
                 t = ts.node(v.site.mutations[0].node).time
-            else:
-                t = constants.TIME_MEANINGLESS
             input_file.add_site(
                 v.site.position,
                 v.genotypes,

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -174,7 +174,7 @@ class TestSampleData(unittest.TestCase, DataContainerMixin):
             if len(v.site.mutations) == 1:
                 t = ts.node(v.site.mutations[0].node).time
             else:
-                t = input_file.MEANINGLESS_TIME
+                t = input_file.TIME_MEANINGLESS
             input_file.add_site(
                 v.site.position,
                 v.genotypes,

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -40,6 +40,7 @@ import tskit
 import tsinfer
 import tsinfer.formats as formats
 import tsinfer.exceptions as exceptions
+import tsinfer.constants as constants
 
 
 class DataContainerMixin(object):
@@ -174,7 +175,7 @@ class TestSampleData(unittest.TestCase, DataContainerMixin):
             if len(v.site.mutations) == 1:
                 t = ts.node(v.site.mutations[0].node).time
             else:
-                t = input_file.TIME_MEANINGLESS
+                t = constants.TIME_MEANINGLESS
             input_file.add_site(
                 v.site.position,
                 v.genotypes,

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1950,7 +1950,7 @@ class PathCompressionMixin(object):
     def test_simulation_with_error(self):
         ts = msprime.simulate(50, mutation_rate=5, random_seed=4, recombination_rate=8)
         ts = eval_util.insert_errors(ts, 0.2, seed=32)
-        sample_data = tsinfer.SampleData.from_tree_sequence(ts)
+        sample_data = tsinfer.SampleData.from_tree_sequence(ts, use_times=False)
         self.verify(sample_data)
 
     def test_small_random_data(self):
@@ -2552,19 +2552,19 @@ class TestAugmentedAncestors(unittest.TestCase):
     def test_simulation_with_error(self):
         ts = msprime.simulate(50, mutation_rate=5, random_seed=5, recombination_rate=8)
         ts = eval_util.insert_errors(ts, 0.1, seed=32)
-        sample_data = tsinfer.SampleData.from_tree_sequence(ts)
+        sample_data = tsinfer.SampleData.from_tree_sequence(ts, use_times=False)
         self.verify(sample_data)
 
     def test_intermediate_simulation_with_error(self):
         ts = msprime.simulate(10, mutation_rate=5, random_seed=78, recombination_rate=8)
         ts = eval_util.insert_errors(ts, 0.1, seed=32)
-        sample_data = tsinfer.SampleData.from_tree_sequence(ts)
+        sample_data = tsinfer.SampleData.from_tree_sequence(ts, use_times=False)
         self.verify(sample_data)
 
     def test_small_simulation_with_error(self):
         ts = msprime.simulate(5, mutation_rate=5, random_seed=5, recombination_rate=8)
         ts = eval_util.insert_errors(ts, 0.1, seed=32)
-        sample_data = tsinfer.SampleData.from_tree_sequence(ts)
+        sample_data = tsinfer.SampleData.from_tree_sequence(ts, use_times=False)
         self.verify(sample_data)
 
     def test_small_random_data(self):

--- a/tsinfer/constants.py
+++ b/tsinfer/constants.py
@@ -19,6 +19,8 @@
 """
 Collection of constants used in tsinfer. We also make use of constants defined in tskit.
 """
+import numpy as np
+
 
 C_ENGINE = "C"
 PY_ENGINE = "P"
@@ -31,3 +33,7 @@ NODE_IS_SRB_ANCESTOR = 1 << 17
 # Bit 18 is set in node flags when they are samples inserted to augment existing
 # ancestors.
 NODE_IS_SAMPLE_ANCESTOR = 1 << 18
+
+# Marker constants for node & site time values
+TIME_UNSPECIFIED = -np.inf
+TIME_MEANINGLESS = np.inf  # Placeholder for e.g. freq value for a nonvariable site

--- a/tsinfer/constants.py
+++ b/tsinfer/constants.py
@@ -36,4 +36,3 @@ NODE_IS_SAMPLE_ANCESTOR = 1 << 18
 
 # Marker constants for node & site time values
 TIME_UNSPECIFIED = -np.inf
-TIME_MEANINGLESS = np.inf  # Placeholder for e.g. freq value for a nonvariable site

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -1063,13 +1063,15 @@ class SampleData(DataContainer):
             and self.num_samples == other.num_samples
             and self.num_sites == other.num_sites
             and self.num_inference_sites == other.num_inference_sites
-            and np.all(self.individuals_time[:] == other.individuals_time[:])
+            and np.allclose(
+                self.individuals_time[:], other.individuals_time[:], equal_nan=True
+            )
             and np.all(self.samples_individual[:] == other.samples_individual[:])
             and np.all(self.samples_population[:] == other.samples_population[:])
             and np.all(self.sites_position[:] == other.sites_position[:])
             and np.all(self.sites_inference[:] == other.sites_inference[:])
             and np.all(self.sites_genotypes[:] == other.sites_genotypes[:])
-            and np.all(self.sites_time[:] == other.sites_time[:])
+            and np.allclose(self.sites_time[:], other.sites_time[:], equal_nan=True)
             # Need to take a different approach with np object arrays.
             and all(
                 itertools.starmap(
@@ -1203,7 +1205,7 @@ class SampleData(DataContainer):
         for v in ts.variants():
             variant_time = constants.TIME_UNSPECIFIED
             if use_times:
-                variant_time = constants.TIME_MEANINGLESS
+                variant_time = np.nan
                 if len(v.site.mutations) == 1:
                     variant_time = ts.node(v.site.mutations[0].node).time
             site_metadata = None

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -782,8 +782,8 @@ class SampleData(DataContainer):
     ADDING_SITES = 2
 
     # Marker constants for time value
-    USE_FREQ_AS_TIME = -np.inf  # Placeholder to mark freq of derived alleles as time
-    MEANINGLESS_TIME = np.inf  # Placeholder for e.g. time value for a nonvariable site
+    TIME_UNSPECIFIED = -np.inf  # Placeholder to mark freq of derived alleles as time
+    TIME_MEANINGLESS = np.inf  # Placeholder for e.g. freq value for a nonvariable site
 
     def __init__(self, sequence_length=0, **kwargs):
 
@@ -1204,9 +1204,9 @@ class SampleData(DataContainer):
                     samples_metadata=[sample_metadata],
                 )
         for v in ts.variants():
-            variant_time = self.USE_FREQ_AS_TIME
+            variant_time = self.TIME_UNSPECIFIED
             if use_times:
-                variant_time = self.MEANINGLESS_TIME
+                variant_time = self.TIME_MEANINGLESS
                 if len(v.site.mutations) == 1:
                     variant_time = ts.node(v.site.mutations[0].node).time
             site_metadata = None
@@ -1476,7 +1476,7 @@ class SampleData(DataContainer):
             if inference:
                 raise ValueError("Cannot use singletons or fixed sites for inference")
         if time is None:
-            time = self.USE_FREQ_AS_TIME
+            time = self.TIME_UNSPECIFIED
         site_id = self._sites_writer.add(
             position=position,
             genotypes=genotypes,

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -43,6 +43,7 @@ import attr
 import tsinfer.threads as threads
 import tsinfer.provenance as provenance
 import tsinfer.exceptions as exceptions
+import tsinfer.constants as constants
 
 
 logger = logging.getLogger(__name__)
@@ -781,10 +782,6 @@ class SampleData(DataContainer):
     ADDING_SAMPLES = 1
     ADDING_SITES = 2
 
-    # Marker constants for time value
-    TIME_UNSPECIFIED = -np.inf  # Placeholder to mark freq of derived alleles as time
-    TIME_MEANINGLESS = np.inf  # Placeholder for e.g. freq value for a nonvariable site
-
     def __init__(self, sequence_length=0, **kwargs):
 
         super().__init__(**kwargs)
@@ -1204,9 +1201,9 @@ class SampleData(DataContainer):
                     samples_metadata=[sample_metadata],
                 )
         for v in ts.variants():
-            variant_time = self.TIME_UNSPECIFIED
+            variant_time = constants.TIME_UNSPECIFIED
             if use_times:
-                variant_time = self.TIME_MEANINGLESS
+                variant_time = constants.TIME_MEANINGLESS
                 if len(v.site.mutations) == 1:
                     variant_time = ts.node(v.site.mutations[0].node).time
             site_metadata = None
@@ -1476,7 +1473,7 @@ class SampleData(DataContainer):
             if inference:
                 raise ValueError("Cannot use singletons or fixed sites for inference")
         if time is None:
-            time = self.TIME_UNSPECIFIED
+            time = constants.TIME_UNSPECIFIED
         site_id = self._sites_writer.add(
             position=position,
             genotypes=genotypes,

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -469,7 +469,7 @@ class AncestorsGenerator(object):
         logger.info("Starting addition of {} sites".format(self.num_sites))
         progress = self.progress_monitor.get("ga_add_sites", self.num_sites)
         for j, variant in enumerate(self.sample_data.variants(inference_sites=True)):
-            self.ancestor_builder.add_site(j, variant.site.time, variant.genotypes)
+            self.ancestor_builder.add_site(j, variant.inference_time, variant.genotypes)
             progress.update()
         progress.close()
         logger.info("Finished adding sites")

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -470,7 +470,7 @@ class AncestorsGenerator(object):
         progress = self.progress_monitor.get("ga_add_sites", self.num_sites)
         for j, variant in enumerate(self.sample_data.variants(inference_sites=True)):
             time = variant.site.time
-            if time == self.sample_data.USE_FREQ_AS_TIME:
+            if time == self.sample_data.TIME_UNSPECIFIED:
                 counts = formats.allele_counts(variant.genotypes)
                 # Non-variable sites have no obvious freq-as-time values
                 assert counts.known != counts.derived

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -464,19 +464,21 @@ class AncestorsGenerator(object):
 
     def add_sites(self):
         """
-        Add all sites from the sample_data object into the ancestor builder.
+        Add all sites marked for inference in the sample_data object into the
+        ancestor builder.
         """
         logger.info("Starting addition of {} sites".format(self.num_sites))
         progress = self.progress_monitor.get("ga_add_sites", self.num_sites)
         for j, variant in enumerate(self.sample_data.variants(inference_sites=True)):
             time = variant.site.time
-            if time == self.sample_data.TIME_UNSPECIFIED:
+            if time == constants.TIME_UNSPECIFIED:
                 counts = formats.allele_counts(variant.genotypes)
                 # Non-variable sites have no obvious freq-as-time values
                 assert counts.known != counts.derived
                 assert counts.known != counts.ancestral
+                assert counts.known > 0
                 # Time = freq of *all* derived alleles. Note that if n_alleles > 2 this
-                # may not be sensible, but checking it means counting alleles (=slow)
+                # may not be sensible: https://github.com/tskit-dev/tsinfer/issues/228
                 time = counts.derived / counts.known
             self.ancestor_builder.add_site(j, time, variant.genotypes)
             progress.update()


### PR DESCRIPTION
I think this is a reasonably neat and non-invasive way to store the information that a site has been marked as "use freq as a proxy for time". The `Variant` object gains an additional attribute, `inference_time`, which is the site.time if the user defined it, otherwise it is the frequency. This seems a reasonable attribute of a *variant* rather than a *site* to me, as it changes depending on the samples that are passed in.

~~Although the tests pass as-is, one thing which is a bit of a hack is the `from_tree_sequence` method. Here, for a non-variable site (no mutations), we set the `site.time` to -np.inf (i.e. `USE_FREQ_AS_TIME`). I would prefer it, I think, if we set them to `np.inf` (or `np.nan`, although that seems to raise other issues), as a marker that the concept of a variant time is nonsensical for a non-variable site. However, that leads to `test_formats.py:TestSampleData.test_from_tree_sequence_variable_allele_number` failing (can't round-trip), so I haven't implemented it until I get some feedback.~~ (corrected in latest push)