### PR TITLE
Make PC_ANCESTOR_INCREMENT smaller.

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -672,9 +672,7 @@ def imputation_accuracy_worker(args):
                 var.site.position, alleles=var.alleles, genotypes=G[var.site.id]
             )
 
-    # FIXME need to turn off path compression when running this with n=1000
-    # as we get a ASSERTION_ERROR otherwise.
-    ts_inferred = tsinfer.infer(sample_data, path_compression=False)
+    ts_inferred = tsinfer.infer(sample_data)
     assert ts_inferred.num_sites == ts.num_sites
     total_missing = np.sum(missing)
     num_correct = 0

--- a/lib/tree_sequence_builder.c
+++ b/lib/tree_sequence_builder.c
@@ -28,8 +28,11 @@
 
 /* Time increment between path compression ancestors and their parents.
  * Power-of-two value chosen here so that we can manipulate time values
- * reasonably losslessly. */
-#define PC_ANCESTOR_INCREMENT (1.0 / 65536)
+ * reasonably losslessly. This is about 2.3e-10. This should be enough
+ * that even with very large samples (and therefore small frequency
+ * values) we have enough space to add many synthetic ancestors. It's a
+ * hack though, and we should have a better approach. */
+#define PC_ANCESTOR_INCREMENT (1.0 / (1LL << 32))
 
 static int
 cmp_edge_left_increasing_time(const void *a, const void *b)

--- a/tsinfer/algorithm.py
+++ b/tsinfer/algorithm.py
@@ -392,9 +392,9 @@ class TreeSequenceBuilder(object):
             edge = edge.next
         assert min_parent_time >= 0
         assert min_parent_time <= self.time[0]
-        # For the assertion to be violated we would need to have 64K pc
-        # ancestors sequentially copying from each other.
-        self.time[pc_parent_id] = min_parent_time - (1 / 2 ** 16)
+        # 1 / 2**32 is the value used in the low-level code.
+        # We'll want to make this more sophisticated in the future
+        self.time[pc_parent_id] = min_parent_time - (1 / 2 ** 32)
         assert self.time[pc_parent_id] > self.time[child_id]
 
     def create_pc_node(self, matches):


### PR DESCRIPTION
Should work better with frequency based times (since #252), but will be
significantly worse for user inputs with large times (#210). This is a
stopgap, as path compression needs to be revisited.