### PR TITLE
Move away from determining inference sites at import time.

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -6,8 +6,9 @@ import tqdm
 import pprint
 import numpy as np
 import json
-import tskit
 import msprime
+
+# import tskit
 
 import tsinfer
 
@@ -89,7 +90,7 @@ def tsinfer_dev(
 
     with tsinfer.SampleData(sequence_length=source_ts.sequence_length) as samples:
         for var in source_ts.variants():
-            var.genotypes[var.site.id % source_ts.num_samples] = tskit.MISSING_DATA
+            # var.genotypes[var.site.id % source_ts.num_samples] = tskit.MISSING_DATA
             samples.add_site(var.site.position, var.genotypes, var.alleles)
 
     # print(samples)
@@ -123,6 +124,7 @@ def tsinfer_dev(
         mutation_rate=mu,
     )
     # print(ancestors_ts.tables)
+
     # print("ancestors ts")
     # for tree in ancestors_ts.trees():
     #     print(tree.draw_text())
@@ -325,7 +327,7 @@ if __name__ == "__main__":
     # copy_1kg()
     tsinfer_dev(
         8,
-        0.15,
+        0.05,
         seed=4,
         num_threads=0,
         engine="P",

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1315,7 +1315,7 @@ class TestAncestorsTreeSequenceIndividuals(unittest.TestCase):
             flags=tables.nodes.flags, time=tables.nodes.time, individual=individual
         )
         ts = tables.tree_sequence()
-        with tsinfer.SampleData() as samples:
+        with tsinfer.SampleData(sequence_length=ts.sequence_length) as samples:
             for j in range(ts.num_samples // 2):
                 samples.add_individual(ploidy=2, location=[100 * j], metadata={"X": j})
             for var in ts.variants():
@@ -1785,6 +1785,7 @@ class TestWrongAncestorsTreeSequence(unittest.TestCase):
         sample_data = tsinfer.SampleData.from_tree_sequence(sim)
         inferred_ts = tsinfer.infer(sample_data)
         self.assertRaises(ValueError, tsinfer.match_samples, sample_data, inferred_ts)
+        # tsinfer.match_samples(sample_data, inferred_ts)
 
     def test_original_ts_match_samples(self):
         sim = msprime.simulate(sample_size=6, random_seed=1, mutation_rate=6)


### PR DESCRIPTION
WIP

First pass is to refactor the main inference code to stop using the ``sample_data.sites_inference`` array. This is fine because both the AncestorData and ancestors tree sequence store the site positions that are actually used.