### PR TITLE
Determine 'inference sites' at ancestor build time.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@
   0/1 values as before.
 - Times for undated sites now use frequencies (0..1), not as counts (1..num_samples),
   and are now stored as -inf, then calculated on the fly in the variants() iterator.
+- The SampleData file no longer accepts the ``inference`` argument to add_site.
+  This functionality has been replaced by the ``exclude_positions`` argument
+  to the ``infer`` and ``generate_ancestors`` functions.
 
 ********************
 [0.1.5] - 2019-09-25

--- a/dev.py
+++ b/dev.py
@@ -93,7 +93,7 @@ def tsinfer_dev(
             # var.genotypes[var.site.id % source_ts.num_samples] = tskit.MISSING_DATA
             samples.add_site(var.site.position, var.genotypes, var.alleles)
 
-    # print(samples)
+    print(samples)
     # for variant in samples.variants():
     #     print(variant)
 
@@ -112,6 +112,7 @@ def tsinfer_dev(
     ancestor_data = tsinfer.generate_ancestors(
         samples, engine=engine, num_threads=num_threads
     )
+    print(ancestor_data)
 
     ancestors_ts = tsinfer.match_ancestors(
         samples,
@@ -152,15 +153,16 @@ def tsinfer_dev(
         precision=precision,
         simplify=False,
     )
+    # print(ts.tables)
 
-    for var1, var2, var3 in zip(
-        source_ts.variants(), ts.variants(), samples.variants()
-    ):
-        if np.any(var1.genotypes != var2.genotypes):
-            print("mismatch at ", var1.site.id)
-            print(var1.genotypes)
-            print(var2.genotypes)
-            print(var3.genotypes)
+    #     for var1, var2, var3 in zip(
+    #         source_ts.variants(), ts.variants(), samples.variants()
+    #     ):
+    #         if np.any(var1.genotypes != var2.genotypes):
+    #             print("mismatch at ", var1.site.id)
+    #             print(var1.genotypes)
+    #             print(var2.genotypes)
+    #             print(var3.genotypes)
 
     print("num_edges = ", ts.num_edges)
 
@@ -192,7 +194,7 @@ def tsinfer_dev(
     # for tree in ts.trees():
     #     print(tree.draw(format="unicode"))
 
-    # tsinfer.verify(samples, ts)
+    tsinfer.verify(samples, ts)
 
 
 #     # output_ts = tsinfer.match_samples(subset_samples, ancestors_ts, engine=engine)
@@ -322,15 +324,17 @@ if __name__ == "__main__":
     # build_profile_inputs(10**4, 100)
     # build_profile_inputs(10**5, 100)
 
-    # for j in range(1, 100):
-    #     tsinfer_dev(15, 0.5, seed=j, num_threads=0, engine="P", recombination_rate=1e-8)
+    # for j in range(1, 1000):
+    # for j in [96]:
+    #     print("seed = ", j)
+    #     tsinfer_dev(5, 0.5, seed=j, num_threads=0, engine="P", recombination_rate=1e-8)
     # copy_1kg()
     tsinfer_dev(
         8,
         0.05,
         seed=4,
         num_threads=0,
-        engine="P",
+        engine="C",
         recombination_rate=1e-8,
         precision=0,
     )

--- a/lib/err.h
+++ b/lib/err.h
@@ -20,6 +20,8 @@
 #define TSI_ERR_BAD_MUTATION_SITE                                   -16
 #define TSI_ERR_BAD_MUTATION_DERIVED_STATE                          -17
 #define TSI_ERR_BAD_MUTATION_DUPLICATE_NODE                         -18
+#define TSI_ERR_BAD_NUM_SAMPLES                                     -19
+#define TSI_ERR_TOO_MANY_SITES                                      -20
 // clang-format on
 
 #ifdef __GNUC__

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -373,7 +373,7 @@ run_random_data(size_t num_samples, size_t num_sites, int seed,
             genotypes[k] = samples[k][j];
             time += genotypes[k];
         }
-        ret = ancestor_builder_add_site(&ancestor_builder, j, time, genotypes);
+        ret = ancestor_builder_add_site(&ancestor_builder, time, genotypes);
         CU_ASSERT_EQUAL_FATAL(ret, 0);
     }
     ret = ancestor_builder_finalise(&ancestor_builder);
@@ -437,6 +437,30 @@ run_random_data(size_t num_samples, size_t num_sites, int seed,
 }
 
 static void
+test_ancestor_builder_errors(void)
+{
+    int ret = 0;
+    ancestor_builder_t ancestor_builder;
+    allele_t genotypes[4] = { 1, 1, 1, 1 };
+
+    ret = ancestor_builder_alloc(&ancestor_builder, 0, 1, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSI_ERR_BAD_NUM_SAMPLES);
+    ancestor_builder_free(&ancestor_builder);
+
+    ret = ancestor_builder_alloc(&ancestor_builder, 1, 1, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, TSI_ERR_BAD_NUM_SAMPLES);
+    ancestor_builder_free(&ancestor_builder);
+
+    ret = ancestor_builder_alloc(&ancestor_builder, 2, 0, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(ancestor_builder.num_sites, 0);
+    ret = ancestor_builder_add_site(&ancestor_builder, 4, genotypes);
+    CU_ASSERT_EQUAL_FATAL(ret, TSI_ERR_TOO_MANY_SITES);
+
+    ancestor_builder_free(&ancestor_builder);
+}
+
+static void
 test_ancestor_builder_one_site(void)
 {
     int ret = 0;
@@ -447,7 +471,7 @@ test_ancestor_builder_one_site(void)
 
     ret = ancestor_builder_alloc(&ancestor_builder, 4, 1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    ret = ancestor_builder_add_site(&ancestor_builder, 0, 4, genotypes);
+    ret = ancestor_builder_add_site(&ancestor_builder, 4, genotypes);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = ancestor_builder_finalise(&ancestor_builder);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
@@ -813,6 +837,7 @@ main(int argc, char **argv)
     CU_pTest test;
     CU_pSuite suite;
     CU_TestInfo tests[] = {
+        { "test_ancestor_builder_errors", test_ancestor_builder_errors },
         { "test_ancestor_builder_one_site", test_ancestor_builder_one_site },
         /* TODO more ancestor builder tests */
         { "test_matching_one_site", test_matching_one_site },

--- a/lib/tsinfer.h
+++ b/lib/tsinfer.h
@@ -102,6 +102,7 @@ typedef struct {
 
 typedef struct {
     size_t num_sites;
+    size_t max_sites;
     size_t num_samples;
     size_t num_ancestors;
     int flags;
@@ -198,7 +199,7 @@ int ancestor_builder_alloc(
 int ancestor_builder_free(ancestor_builder_t *self);
 int ancestor_builder_print_state(ancestor_builder_t *self, FILE *out);
 int ancestor_builder_add_site(
-    ancestor_builder_t *self, tsk_id_t site, double time, allele_t *genotypes);
+    ancestor_builder_t *self, double time, allele_t *genotypes);
 int ancestor_builder_make_ancestor(ancestor_builder_t *self, size_t num_focal_sites,
     tsk_id_t *focal_sites, tsk_id_t *start, tsk_id_t *end, allele_t *haplotype);
 int ancestor_builder_finalise(ancestor_builder_t *self);

--- a/tests/test_low_level.py
+++ b/tests/test_low_level.py
@@ -96,3 +96,40 @@ class TestTreeSequenceBuilder(unittest.TestCase):
                 _tsinfer.TreeSequenceBuilder([2], max_nodes=bad_type)
             with self.assertRaises(TypeError):
                 _tsinfer.TreeSequenceBuilder([2], max_edges=bad_type)
+
+
+class TestAncestorBuilder(unittest.TestCase):
+    """
+    Tests for the AncestorBuilder C Python interface.
+    """
+
+    def test_init(self):
+        self.assertRaises(TypeError, _tsinfer.AncestorBuilder)
+        for bad_value in [None, "serf", [[], []], ["asdf"], {}]:
+            with self.assertRaises(TypeError):
+                _tsinfer.AncestorBuilder(num_samples=2, max_sites=bad_value)
+                _tsinfer.AncestorBuilder(num_samples=bad_value, max_sites=2)
+
+        for bad_num_samples in [0, 1]:
+            with self.assertRaises(_tsinfer.LibraryError):
+                _tsinfer.AncestorBuilder(num_samples=bad_num_samples, max_sites=0)
+
+    def test_add_site(self):
+        ab = _tsinfer.AncestorBuilder(num_samples=2, max_sites=10)
+        for bad_type in ["sdf", {}, None]:
+            with self.assertRaises(TypeError):
+                ab.add_site(time=bad_type, genotypes=[0, 0])
+        for bad_genotypes in ["asdf", [[], []], [0, 1, 2]]:
+            with self.assertRaises(ValueError):
+                ab.add_site(time=0, genotypes=bad_genotypes)
+
+    def test_add_too_many_sites(self):
+        for max_sites in range(10):
+            ab = _tsinfer.AncestorBuilder(num_samples=2, max_sites=max_sites)
+            for j in range(max_sites):
+                ab.add_site(time=1, genotypes=[0, 1])
+            for j in range(2 * max_sites):
+                with self.assertRaises(_tsinfer.LibraryError):
+                    ab.add_site(time=1, genotypes=[0, 1])
+
+    # TODO need tester methods for the remaining methonds in the class.

--- a/tsinfer/algorithm.py
+++ b/tsinfer/algorithm.py
@@ -65,10 +65,9 @@ class AncestorBuilder(object):
     This implementation partially allows for multiple focal sites per ancestor
     """
 
-    def __init__(self, num_samples, num_sites):
+    def __init__(self, num_samples, max_sites):
         self.num_samples = num_samples
-        self.num_sites = num_sites
-        self.sites = [None for _ in range(self.num_sites)]
+        self.sites = []
         # Create a mapping from time to sites. Different sites can exist at the same
         # timepoint. If we expect them to be part of the same ancestor node we can give
         # them the same ancestor_uid: the time_map contains values keyed by time, with
@@ -77,11 +76,16 @@ class AncestorBuilder(object):
         # defaultdict of defaultdicts
         self.time_map = collections.defaultdict(lambda: collections.defaultdict(list))
 
-    def add_site(self, site_id, time, genotypes):
+    @property
+    def num_sites(self):
+        return len(self.sites)
+
+    def add_site(self, time, genotypes):
         """
         Adds a new site at the specified ID to the builder.
         """
-        self.sites[site_id] = Site(site_id, time, genotypes)
+        site_id = len(self.sites)
+        self.sites.append(Site(site_id, time, genotypes))
         sites_at_fixed_timepoint = self.time_map[time]
         # Sites with an identical variant distribution (i.e. with the same
         # genotypes.tobytes() value) and at the same time, are put into the same ancestor

--- a/tsinfer/constants.py
+++ b/tsinfer/constants.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018 University of Oxford
+# Copyright (C) 2018-2020 University of Oxford
 #
 # This file is part of tsinfer.
 #
@@ -25,6 +25,9 @@ import numpy as np
 C_ENGINE = "C"
 PY_ENGINE = "P"
 
+
+# TODO Change these to use the enum.IntFlag class
+
 # Bit 16 is set in node flags when they have been created by path compression.
 NODE_IS_PC_ANCESTOR = 1 << 16
 # Bit 17 is set in node flags when they have been created by shared recombination
@@ -36,3 +39,7 @@ NODE_IS_SAMPLE_ANCESTOR = 1 << 18
 
 # Marker constants for node & site time values
 TIME_UNSPECIFIED = -np.inf
+
+# What type of inference have we done at a site?
+INFERENCE_FULL = "full"
+INFERENCE_FITCH_PARSIMONY = "fitch_parsimony"


### PR DESCRIPTION
Deciding what sites to use as inference at import time is inflexible and creates unwanted linkage between the SampleData file and the AncestorBuilder. The SampleData file should not  be making any semantic judgements on what the AncestorBuilder things is good input for it to work with.

This changes the semantics so that the decision about whether to use a site for inference or not is decided when we add the site to the AncestorBuilder. The user can still state that the definitely want the site to be used for inference or not, but by default the AncestorBuilder will decide.

The basic update worked easily enough and the core inference is working well. Predictably though, this has broken a bunch of stuff in the tests and the ancillary tools. We use the idea of ``inference_sites`` quite a lot.

Since the term ``inference_sites`` isn't particularly well chosen anyway (we still do inference on the other sites, we just don't use them in building ancestral haplotypes), I'm tempted to change the terminology entirely and raise and error if someone uses the ``inference_sites`` approach. Code that depends on ``SampleData.sites_inference`` is most likely broken now anyway, so it may be the safest thing to do.

Any thoughts here @hyanwong?