### PR TITLE
Count lower freq conflicts

### DIFF
--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -110,7 +110,7 @@ with other individuals.
 
 In ``tsinfer``, metadata can be stored by providing a JSON encodable
 mapping. This information is then stored as JSON, and embedded in the
-final tree sequence object and can be recovered using the ``msprime``
+final tree sequence object and can be recovered using the ``tskit``
 APIs.
 
 .. _sec_inference_import_samples:

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -16,7 +16,7 @@ make two very important gains:
 2. The data structure itself is an extremely concise and efficient means of
    storing and processing the data that we have.
 
-The output of ``tsinfer`` is an :class:`msprime.TreeSequence` and so the
+The output of ``tsinfer`` is a :class:`tskit.TreeSequence` and so the
 full `tskit API <https://tskit.readthedocs.io>`_ can be used to
 analyse real data, in precisely the same way that it is commonly used
 to analyse simulation data, for example, from `msprime <https://msprime.readthedocs.io/>`_.

--- a/lib/ancestor_builder.c
+++ b/lib/ancestor_builder.c
@@ -229,7 +229,7 @@ ancestor_builder_compute_ancestral_states(ancestor_builder_t *self, int directio
     if (sample_set_size<3) {
         min_sample_set_size = 1;
     } else {
-        min_sample_set_size = sample_set_size / 3;
+        min_sample_set_size = 3 * sample_set_size / 4;
     }
     /* printf("site=%d, direction=%d min_sample_size=%d, derived=%d\n",
         (int) focal_site, direction,

--- a/lib/ancestor_builder.c
+++ b/lib/ancestor_builder.c
@@ -226,7 +226,11 @@ ancestor_builder_compute_ancestral_states(ancestor_builder_t *self, int directio
      * ancestor_builder_compute_between_focal_sites */
     assert(sample_set_size > 0);
     memset(remove_buffer, 0, self->num_samples * sizeof(*remove_buffer));
-    min_sample_set_size = sample_set_size / 2;
+    if (sample_set_size<3) {
+        min_sample_set_size = 1;
+    } else {
+        min_sample_set_size = sample_set_size / 3;
+    }
     /* printf("site=%d, direction=%d min_sample_size=%d, derived=%d\n",
         (int) focal_site, direction,
         (int) min_sample_set_size, (int) sites[focal_site].n_derived); */
@@ -273,21 +277,16 @@ ancestor_builder_compute_ancestral_states(ancestor_builder_t *self, int directio
                     if (genotypes[u] == consensus) {
                         remove_buffer[u] = 0;
                     } else {
-                        if (genotypes[u] == TSK_MISSING_DATA) {
-                            /* Leave the buffer as-is */
+                        if (remove_buffer[u] == 1) {
+                            /* This sample has disagreed with consensus twice in a
+                             * row, so remove it */
+                            /* printf("\t\tremoving %d\n", sample_set[j]); */
+                            sample_set[j] = -1;
                         } else {
-                            if (remove_buffer[u] == 1) {
-                                /* This sample has disagreed with consensus twice in a
-                                 * row, so remove it */
-                                /* printf("\t\tremoving %d\n", sample_set[j]); */
-                                sample_set[j] = -1;
-                            } else {
-                                remove_buffer[u] = 1;
-                            }
+                            remove_buffer[u] = 1;
                         }
                     }
                 }
-                ancestor[i] = consensus;
                 /* Repack the sample set */
                 tmp_size = 0;
                 for (j = 0; j < sample_set_size; j++) {

--- a/lib/tsinfer.h
+++ b/lib/tsinfer.h
@@ -66,6 +66,7 @@ typedef struct _node_segment_list_node_t {
 
 typedef struct {
     double time;
+    size_t n_derived;
     allele_t *genotypes;
 } site_t;
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1159,7 +1159,7 @@ class TestAncestorGeneratorsEquivalant:
         #     j += 1
         # print(adc)
         # print(adp)
-        assert adp.data_equal(adc)
+        adp.assert_data_equal(adc)
         return adp, adc
 
     def verify_tree_sequence(self, ts):

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -2242,6 +2242,26 @@ class AncestorData(DataContainer):
             and np_obj_equal(self.ancestors_haplotype[:], other.ancestors_haplotype[:])
         )
 
+    def assert_data_equal(self, other):
+        """
+        The same as :meth:`.data_equal`, but raises an assertion rather than returning
+        False. This is useful for testing.
+        """
+        assert self.sequence_length == other.sequence_length
+        assert self.sample_data_uuid == other.sample_data_uuid
+        assert self.format_name == other.format_name
+        assert self.format_version == other.format_version
+        assert self.num_ancestors == other.num_ancestors
+        assert self.num_sites == other.num_sites
+        assert np.array_equal(self.sites_position[:], other.sites_position[:])
+        assert np.array_equal(self.ancestors_start[:], other.ancestors_start[:])
+        assert np.array_equal(self.ancestors_end[:], other.ancestors_end[:])
+        # Need to take a different approach with np object arrays.
+        assert np_obj_equal(
+            self.ancestors_focal_sites[:], other.ancestors_focal_sites[:]
+        )
+        assert np_obj_equal(self.ancestors_haplotype[:], other.ancestors_haplotype[:])
+
     @property
     def sequence_length(self):
         return self.data.attrs["sequence_length"]


### PR DESCRIPTION
Here's the alternative python code that reduces the sample set size when building ancestors even if the site is at lower freq (I think this is essentially performing the four gamete test between the focal site and the adjacent ones). It will probably make ancestor building slower, as we are checking every site now, not just the lower freq ones. But ancestor building is the quick part of inference anyway. Since this builds shorter ancestors, matching should become way faster, and we don't need the cutoff_exponent hack described in https://github.com/tskit-dev/tsinfer/issues/276. 

This seems to produce reasonable inference on both OOA simulations with injected error (sequencing error and ancestral state polarity error), and also with a subset of 10000 sites of HGDP chromosome 20. So I think it's worth coding in C to try on a larger example.

The excess length of ancestors produced by the C code (blue points below) is reduced substantially in this python version (red points):

![image](https://user-images.githubusercontent.com/4699014/86393847-85410000-bc95-11ea-9d9e-af590d8ba852.png)
