### PR TITLE
Return the new ID from add_ancestor

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1496,8 +1496,13 @@ class TestAncestorData(unittest.TestCase, DataContainerMixin):
         return sample_data, ancestors
 
     def verify_data_round_trip(self, sample_data, ancestor_data, ancestors):
-        for start, end, t, focal_sites, haplotype in ancestors:
-            ancestor_data.add_ancestor(start, end, t, focal_sites, haplotype[start:end])
+        for i, (start, end, t, focal_sites, haplotype) in enumerate(ancestors):
+            self.assertEqual(
+                i,
+                ancestor_data.add_ancestor(
+                    start, end, t, focal_sites, haplotype[start:end]
+                ),
+            )
         ancestor_data.record_provenance("verify_data_round_trip")
         ancestor_data.finalise()
 

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -1959,7 +1959,8 @@ class AncestorData(DataContainer):
         """
         Adds an ancestor with the specified haplotype, with ancestral material
         over the interval [start:end], that is associated with the specified timepoint
-        and has new mutations at the specified list of focal sites.
+        and has new mutations at the specified list of focal sites. The id of the added
+        ancestor is returned
         """
         self._check_build_mode()
         haplotype = tskit.util.safe_np_int_cast(haplotype, dtype=np.int8, copy=True)
@@ -1980,7 +1981,7 @@ class AncestorData(DataContainer):
             raise ValueError("time must be > 0")
         if np.any(focal_sites < start) or np.any(focal_sites >= end):
             raise ValueError("focal sites must be between start and end")
-        self.item_writer.add(
+        return self.item_writer.add(
             start=start,
             end=end,
             time=time,


### PR DESCRIPTION
This is a useful addition if we are adding ancestors by hand, and want to keep track of the ID of the just-added one. We can't use `anc.num_ancestors` because the writing is buffered, so the array size may not be up to date. I'm guessing that `self.item_writer.total_items - 1` should always give the correct ID, even when using multiple threads for writing, and it seems to be fine in the single threaded case. Am I right here @jeromekelleher ?

If we can get this merged, then along with https://github.com/tskit-dev/tsinfer/pull/288 it's basically the last piece of the puzzle for getting a simple alternative to `match_ancestors` working that inserts non-contemporaneous samples as ancestors in the right place, so it would be good to get this merged.