### PR TITLE
Add a population object, and accessors

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -327,6 +327,30 @@ class TestSampleData(unittest.TestCase, DataContainerMixin):
         with formats.SampleData(sequence_length=ts.sequence_length) as sample_data:
             self.verify_data_round_trip(ts, sample_data)
 
+    def test_access_individuals(self):
+        ts = self.get_example_individuals_ts_with_metadata(5, 2, 10, 1)
+        sd = tsinfer.SampleData.from_tree_sequence(ts)
+        self.assertGreater(sd.num_individuals, 0)
+        has_some_metadata = False
+        for i, individual in enumerate(sd.individuals()):
+            if individual.metadata:
+                has_some_metadata = True  # Check that we do compare something sometimes
+            self.assertTrue(individual.metadata == sd.individual(i).metadata)
+        self.assertTrue(has_some_metadata)
+        self.assertEqual(i, sd.num_individuals - 1)
+
+    def test_access_populations(self):
+        ts = self.get_example_individuals_ts_with_metadata(5, 2, 10, 1)
+        sd = tsinfer.SampleData.from_tree_sequence(ts)
+        self.assertGreater(sd.num_individuals, 0)
+        has_some_metadata = False
+        for i, population in enumerate(sd.populations()):
+            if population.metadata:
+                has_some_metadata = True  # Check that we do compare something sometimes
+            self.assertTrue(population.metadata == sd.population(i).metadata)
+        self.assertTrue(has_some_metadata)
+        self.assertEqual(i, sd.num_populations - 1)
+
     def test_from_tree_sequence_bad_times(self):
         n_individuals = 4
         sample_times = np.arange(n_individuals * 2)  # Diploids

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -671,6 +671,17 @@ class Individual(object):
     metadata = attr.ib()
 
 
+@attr.s
+class Population(object):
+    """
+    An Population object. Mirrors the definition in tskit.
+    """
+
+    # TODO document properly.
+    id = attr.ib()
+    metadata = attr.ib()
+
+
 class SampleData(DataContainer):
     """
     SampleData(sequence_length=0, path=None, num_flush_threads=0, \
@@ -1702,6 +1713,7 @@ class SampleData(DataContainer):
                 j += 1
 
     def individual(self, id_):
+        # TODO document
         return Individual(
             id_,
             location=self.individuals_location[id_],
@@ -1718,6 +1730,16 @@ class SampleData(DataContainer):
         )
         for j, (location, metadata, time) in enumerate(iterator):
             yield Individual(j, location=location, metadata=metadata, time=time)
+
+    def population(self, id_):
+        # TODO document
+        return Population(id_, metadata=self.populations_metadata[id_],)
+
+    def populations(self):
+        # TODO document
+        iterator = self.populations_metadata[:]
+        for j, metadata in enumerate(iterator):
+            yield Population(j, metadata=metadata)
 
 
 @attr.s


### PR DESCRIPTION
We previously had no way to get a population from a sample data file. This implements functions for populations in the same way as currently exist for individuals (but more simply, as there is only metadata, and the definition of a population matches that in tskit)