### PR TITLE
Allow tests to work under tskit 0.2.4

### DIFF
--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1321,7 +1321,7 @@ class TestAncestorsTreeSequenceIndividuals(unittest.TestCase):
             ts.num_individuals,
         )
         # The ancestors individiduals should come first.
-        final_individuals = ts.individuals()
+        final_individuals = iter(ts.individuals())
         for ind in ancestors_ts.individuals():
             final_ind = next(final_individuals)
             self.assertEqual(final_ind, ind)


### PR DESCRIPTION
Currently tests fail under 0.2.4 with 'SimpleContainerSequence' object is not an iterator