### PR TITLE
Ancestors as samples

### DIFF
--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2682,12 +2682,12 @@ class TestAugmentedAncestors(unittest.TestCase):
         k = len(subset)
         m = len(t1.nodes)
         self.assertTrue(
-            np.all(t2.nodes.flags[m : m + k] == tsinfer.NODE_IS_SAMPLE_ANCESTOR)
+            np.all(t2.nodes.flags[m : m + k] == tsinfer.NODE_IS_PROXY_SAMPLE_ANCESTOR)
         )
         self.assertTrue(np.all(t2.nodes.time[m : m + k] == 1))
         for j, node_id in enumerate(subset):
             node = t2.nodes[m + j]
-            self.assertEqual(node.flags, tsinfer.NODE_IS_SAMPLE_ANCESTOR)
+            self.assertEqual(node.flags, tsinfer.NODE_IS_PROXY_SAMPLE_ANCESTOR)
             self.assertEqual(node.time, 1)
             metadata = json.loads(node.metadata.decode())
             self.assertEqual(node_id, metadata["sample_data_id"])
@@ -2736,7 +2736,7 @@ class TestAugmentedAncestors(unittest.TestCase):
             parent = edges[0].parent
             original_node = len(t1.nodes) + j
             self.assertEqual(
-                tables.nodes.flags[original_node], tsinfer.NODE_IS_SAMPLE_ANCESTOR
+                tables.nodes.flags[original_node], tsinfer.NODE_IS_PROXY_SAMPLE_ANCESTOR
             )
             # Most of the time the parent is the original node. However, in
             # simple cases it can be somewhere up the tree above it.
@@ -2841,7 +2841,7 @@ class TestSequentialAugmentedAncestors(TestAugmentedAncestors):
             # Make sure metadata has been preserved in the final ts.
             num_sample_ancestors = 0
             for node in final_ts.nodes():
-                if node.flags == tsinfer.NODE_IS_SAMPLE_ANCESTOR:
+                if node.flags == tsinfer.NODE_IS_PROXY_SAMPLE_ANCESTOR:
                     metadata = json.loads(node.metadata.decode())
                     self.assertIn(metadata["sample_data_id"], subset)
                     num_sample_ancestors += 1

--- a/tsinfer/algorithm.py
+++ b/tsinfer/algorithm.py
@@ -260,7 +260,8 @@ class TreeSequenceBuilder(object):
         for t, flag in zip(time, flags):
             self.add_node(t, flag)
 
-    def add_node(self, time, flags=1):
+    def add_node(self, time, flags=tskit.NODE_IS_SAMPLE):
+        # Add a node, marking by default as a sample (as required in an ancestors_ts)
         self.num_nodes += 1
         self.time.append(time)
         self.flags.append(flags)

--- a/tsinfer/constants.py
+++ b/tsinfer/constants.py
@@ -33,9 +33,14 @@ NODE_IS_PC_ANCESTOR = 1 << 16
 # Bit 17 is set in node flags when they have been created by shared recombination
 # breakpoint
 NODE_IS_SRB_ANCESTOR = 1 << 17
-# Bit 18 is set in node flags when they are samples inserted to augment existing
-# ancestors.
-NODE_IS_SAMPLE_ANCESTOR = 1 << 18
+# Bits 18 and 19 should be mutually exclusive. Bit 18 is set in node flags when a node
+# corresponds to an ancestor that is very like a sample genome but is allowed to differ,
+# for example, at sites not used in full inference. Bit 19 is set when a node
+# corresponds to an ancestor that actually *is* a sampled genome (and which might, for
+# example, be associated with an individual in the individuals table). If bit 19 is set
+# it will lead to the tskit.NODE_IS_SAMPLE flag being set on this node by match_samples.
+NODE_IS_PROXY_SAMPLE_ANCESTOR = 1 << 18
+NODE_IS_TRUE_SAMPLE_ANCESTOR = 1 << 19
 
 # Marker constants for node & site time values
 TIME_UNSPECIFIED = -np.inf

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -1469,7 +1469,8 @@ class SampleMatcher(Matcher):
 
     def get_augmented_ancestors_tree_sequence(self, sample_indexes):
         """
-        Return the ancestors tree sequence augmented with samples as extra ancestors.
+        Return the ancestors tree sequence augmented with samples as extra ancestors
+        at the most recent time point.
         """
         logger.debug("Building augmented ancestors tree sequence")
         tsb = self.tree_sequence_builder
@@ -1482,7 +1483,7 @@ class SampleMatcher(Matcher):
             if times[j] == 0.0:
                 # This is an augmented ancestor node.
                 tables.nodes.add_row(
-                    flags=constants.NODE_IS_SAMPLE_ANCESTOR,
+                    flags=constants.NODE_IS_PROXY_SAMPLE_ANCESTOR,
                     time=times[j],
                     metadata=self.encode_metadata(
                         {"sample_data_id": int(sample_indexes[s])}


### PR DESCRIPTION
Here's a draft first pass at a `match_ancestors_including_noncontemporanous_samples`. It's just the general idea, so no tests implemented, but I've tried it out on some code in a Jupyter notebook, which I'll port into a test.

One question is whether to make this an option in the normal `match_ancestors` function or not. Another is whether it should all be in one long function like this (but I've tried splitting it up and putting it into other classes, and I can't quite get it to sit anywhere else).