### PR TITLE
Allow missing data within an ancestor

### DIFF
--- a/lib/ancestor_builder.c
+++ b/lib/ancestor_builder.c
@@ -223,10 +223,9 @@ ancestor_builder_compute_ancestral_states(ancestor_builder_t *self, int directio
 
     ancestor_builder_get_consistent_samples(
         self, focal_site, sample_set, &sample_set_size);
-    if (sample_set_size == 0) {
-        ret = TSI_ERR_BAD_FOCAL_SITE;
-        goto out;
-    }
+    /* This can't happen because we've already tested for it in
+     * ancestor_builder_compute_between_focal_sites */
+    assert(sample_set_size > 0);
     memset(disagree, 0, self->num_samples * sizeof(*disagree));
     min_sample_set_size = sample_set_size / 2;
 
@@ -302,7 +301,6 @@ ancestor_builder_compute_ancestral_states(ancestor_builder_t *self, int directio
         }
     }
     *last_site_ret = last_site;
-out:
     return ret;
 }
 

--- a/lib/err.h
+++ b/lib/err.h
@@ -22,6 +22,7 @@
 #define TSI_ERR_BAD_MUTATION_DUPLICATE_NODE                         -18
 #define TSI_ERR_BAD_NUM_SAMPLES                                     -19
 #define TSI_ERR_TOO_MANY_SITES                                      -20
+#define TSI_ERR_BAD_FOCAL_SITE                                      -21
 // clang-format on
 
 #ifdef __GNUC__

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -446,7 +446,7 @@ test_ancestor_builder_errors(void)
     allele_t genotypes_ones[4] = { 1, 1, 1, 1 };
     allele_t genotypes_zeros[4] = { 0, 0, 0, 0 };
     tsk_id_t start, end;
-    allele_t *haplotype;
+    allele_t haplotype[4];
 
     ret = ancestor_builder_alloc(&ancestor_builder, 0, 1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSI_ERR_BAD_NUM_SAMPLES);
@@ -463,19 +463,19 @@ test_ancestor_builder_errors(void)
     CU_ASSERT_EQUAL_FATAL(ret, TSI_ERR_TOO_MANY_SITES);
     ancestor_builder_free(&ancestor_builder);
 
-    ret = ancestor_builder_alloc(&ancestor_builder, 4, 1, 0);
+    ret = ancestor_builder_alloc(&ancestor_builder, 4, 2, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     ret = ancestor_builder_add_site(&ancestor_builder, 4, genotypes_zeros);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    CU_ASSERT_EQUAL_FATAL(ancestor_builder.num_sites, 1);
+    ret = ancestor_builder_add_site(&ancestor_builder, 4, genotypes_ones);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(ancestor_builder.num_sites, 2);
     ret = ancestor_builder_finalise(&ancestor_builder);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
-    haplotype = malloc(ancestor_builder.num_sites * sizeof(*haplotype));
     ret = ancestor_builder_make_ancestor(&ancestor_builder,
         ancestor_builder.descriptors[0].num_focal_sites,
         ancestor_builder.descriptors[0].focal_sites, &start, &end, haplotype);
     CU_ASSERT_EQUAL_FATAL(ret, TSI_ERR_BAD_FOCAL_SITE);
-    free(haplotype);
 
     ancestor_builder_free(&ancestor_builder);
 }

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -397,12 +397,14 @@ run_random_data(size_t num_samples, size_t num_sites, int seed,
         /* Build the ancestral haplotype */
         ret = ancestor_builder_make_ancestor(&ancestor_builder, ad.num_focal_sites,
             ad.focal_sites, &start, &end, haplotype);
-        CU_ASSERT_EQUAL_FATAL(ret, 0);
-
-        add_haplotype(&tsb, &ancestor_matcher, child, start, end, haplotype);
-        /* printf("\n"); */
-        /* tree_sequence_builder_print_state(&tsb, stdout); */
-        /* printf("\n-----------------\n"); */
+        /* With random data we could ask for an ancestor for a focal site at freq 0 */
+        if (ret != TSI_ERR_BAD_FOCAL_SITE) {
+            CU_ASSERT_EQUAL_FATAL(ret, 0);
+            add_haplotype(&tsb, &ancestor_matcher, child, start, end, haplotype);
+            /* printf("\n"); */
+            /* tree_sequence_builder_print_state(&tsb, stdout); */
+            /* printf("\n-----------------\n"); */
+        }
     }
 
     /* Add the samples */
@@ -441,7 +443,10 @@ test_ancestor_builder_errors(void)
 {
     int ret = 0;
     ancestor_builder_t ancestor_builder;
-    allele_t genotypes[4] = { 1, 1, 1, 1 };
+    allele_t genotypes_ones[4] = { 1, 1, 1, 1 };
+    allele_t genotypes_zeros[4] = { 0, 0, 0, 0 };
+    tsk_id_t start, end;
+    allele_t *haplotype;
 
     ret = ancestor_builder_alloc(&ancestor_builder, 0, 1, 0);
     CU_ASSERT_EQUAL_FATAL(ret, TSI_ERR_BAD_NUM_SAMPLES);
@@ -454,8 +459,23 @@ test_ancestor_builder_errors(void)
     ret = ancestor_builder_alloc(&ancestor_builder, 2, 0, 0);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
     CU_ASSERT_EQUAL_FATAL(ancestor_builder.num_sites, 0);
-    ret = ancestor_builder_add_site(&ancestor_builder, 4, genotypes);
+    ret = ancestor_builder_add_site(&ancestor_builder, 4, genotypes_ones);
     CU_ASSERT_EQUAL_FATAL(ret, TSI_ERR_TOO_MANY_SITES);
+    ancestor_builder_free(&ancestor_builder);
+
+    ret = ancestor_builder_alloc(&ancestor_builder, 4, 1, 0);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    ret = ancestor_builder_add_site(&ancestor_builder, 4, genotypes_zeros);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    CU_ASSERT_EQUAL_FATAL(ancestor_builder.num_sites, 1);
+    ret = ancestor_builder_finalise(&ancestor_builder);
+    CU_ASSERT_EQUAL_FATAL(ret, 0);
+    haplotype = malloc(ancestor_builder.num_sites * sizeof(*haplotype));
+    ret = ancestor_builder_make_ancestor(&ancestor_builder,
+        ancestor_builder.descriptors[0].num_focal_sites,
+        ancestor_builder.descriptors[0].focal_sites, &start, &end, haplotype);
+    CU_ASSERT_EQUAL_FATAL(ret, TSI_ERR_BAD_FOCAL_SITE);
+    free(haplotype);
 
     ancestor_builder_free(&ancestor_builder);
 }

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1029,17 +1029,16 @@ class TestAncestorGeneratorsEquivalant(unittest.TestCase):
                 [1, 1, 1, 1, 0, 0],
             ]
         )
-        # For the haplotype focussed on sites 0 & 2, the relevant values at sites
-        # 1 and 3 in this example are all missing and should default to 0 in both cases
-        expected_hap_focal_site_0 = [1, 0, 1, 0, 1]
-        adp, adc = self.verify_ancestor_generator(G)
-        site_0_anc = [i for i, fs in enumerate(adc.ancestors_focal_sites[:]) if 0 in fs]
+        adp, _ = self.verify_ancestor_generator(G)
+        site_0_anc = [i for i, fs in enumerate(adp.ancestors_focal_sites[:]) if 0 in fs]
         self.assertTrue(len(site_0_anc) == 1)
         site_0_anc = site_0_anc[0]
         # Sites 0 and 2 should share the same ancestor
-        self.assertTrue(np.all(adc.ancestors_focal_sites[:][site_0_anc] == [0, 2]))
-        focal_site_0_haplotype = adc.ancestors_haplotype[:][site_0_anc]
-        # Sites with all missing data should default to 0
+        self.assertTrue(np.all(adp.ancestors_focal_sites[:][site_0_anc] == [0, 2]))
+        focal_site_0_haplotype = adp.ancestors_haplotype[:][site_0_anc]
+        # High freq sites with all missing data (e.g. for sites 1 & 3 in the ancestral
+        # haplotype focussed on sites 0 & 2) should default to tskit.MISSING_DATA
+        expected_hap_focal_site_0 = [1, u, 1, u, 1]
         self.assertTrue(np.all(focal_site_0_haplotype == expected_hap_focal_site_0))
 
     def test_with_recombination_long_threads(self):

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1157,12 +1157,12 @@ class TestBuildAncestors(unittest.TestCase):
             with tsinfer.formats.AncestorData(sample_data) as ancestor_data:
                 g = np.zeros(2, dtype=np.int8)
                 h = np.zeros(1, dtype=np.int8)
-                generator = tsinfer.AncestorsGenerator(
-                    sample_data, ancestor_data, engine=engine,
-                )
-                generator.ancestor_builder.add_site(1, g)
-                with self.assertRaises(error):
-                    generator.ancestor_builder.make_ancestor([0], h)
+            generator = tsinfer.AncestorsGenerator(
+                sample_data, ancestor_data, engine=engine,
+            )
+            generator.ancestor_builder.add_site(1, g)
+            with self.assertRaises(error):
+                generator.ancestor_builder.make_ancestor([0], h)
 
     def get_simulated_example(self, ts):
         sample_data = tsinfer.SampleData.from_tree_sequence(ts)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1145,6 +1145,25 @@ class TestBuildAncestors(unittest.TestCase):
         with self.assertRaises(ValueError):
             tsinfer.generate_ancestors(sample_data, exclude_positions=["not", 1.1])
 
+    def test_bad_focal_sites(self):
+        # Can't generate an ancestor for a site with no mutations
+        with tsinfer.SampleData(1.0) as sample_data:
+            sample_data.add_site(0.5, [0, 0])
+        for engine in [tsinfer.PY_ENGINE]:  # TODO - include C_ENGINE
+            with tsinfer.formats.AncestorData(sample_data) as ancestor_data:
+                g = np.zeros(2, dtype=np.int8)
+                h = np.zeros(1, dtype=np.int8)
+                generator = tsinfer.AncestorsGenerator(
+                    sample_data,
+                    ancestor_data,
+                    engine=engine,
+                    progress_monitor=tsinfer.cli.ProgressMonitor(),
+                )
+                generator.ancestor_builder.add_site(1, g)
+                self.assertRaises(
+                    ValueError, generator.ancestor_builder.make_ancestor, [0], h
+                )
+
     def get_simulated_example(self, ts):
         sample_data = tsinfer.SampleData.from_tree_sequence(ts)
         ancestor_data = tsinfer.generate_ancestors(sample_data)


### PR DESCRIPTION
Following [this comment](https://github.com/tskit-dev/tsinfer/issues/248#issuecomment-662301218), this sticks `tskit.MISSING_DATA` as the value within a haplotype if we really do have no clue as to the possible haplotype value. @awohns is testing it with some real data right now.