### PR TITLE
Add check that singletons are marked as fitch_parsimony

### DIFF
--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -764,11 +764,16 @@ class TestMetadataRoundTrip(unittest.TestCase):
             self.assertEqual(all_metadata[variant.site.id], variant.site.metadata)
 
         output_ts = tsinfer.infer(sample_data)
+        samples = set(output_ts.samples())
         for site in output_ts.sites():
             decoded_metadata = json.loads(site.metadata)
             self.assertIn("inference_type", decoded_metadata)
             value = decoded_metadata.pop("inference_type")
-            self.assertIn(value, ("full", "fitch_parsimony"))
+            # Only singletons should be fitch_parsimony sites in this simple case
+            if len(site.mutations) == 1 and site.mutations[0].node in samples:
+                self.assertEqual(value, "fitch_parsimony")
+            else:
+                self.assertEqual(value, "full")
             self.assertEqual(decoded_metadata, all_metadata[site.id])
 
     def test_population_metadata(self):


### PR DESCRIPTION
It wasn't clear to me that this was explicitly covered in the tests, because the TestNonInferenceSitesRoundTrip class explicitly passes in the list of sites to ignore (including singletons). This checks that with the default settings, singleton sites are fitch_parsimony and others are full_parsimony.