### PR TITLE
Use the seeded rng

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -717,7 +717,7 @@ def run_imputation_accuracy(args):
             work.append((sim_args, missing_proportion))
             # imputation_accuracy_worker((sim_args, missing_proportion))
 
-    random.shuffle(work)
+    rng.shuffle(work)
     progress = tqdm.tqdm(total=len(work), disable=not args.progress)
     results = []
     try:


### PR DESCRIPTION
I noticed that the tests in https://github.com/tskit-dev/tsinfer/pull/306 passed on my machine but not on CI, because the wrong RNG was being used in tests (so that test results varied from one run to another). Oops. This corrects the behaviour.