### PR TITLE
individuals_time carries through into inferred tree sequence

### DIFF
--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -902,6 +902,45 @@ class TestMetadataRoundTrip(unittest.TestCase):
         for location, individual in zip(all_locations, output_ts.individuals()):
             self.assertTrue(np.array_equal(location, individual.location))
 
+    def test_historic_individuals(self):
+        samples = [msprime.Sample(population=0, time=0) for i in range(10)]
+        random.seed(16)
+        rng = random.Random(32)
+        ages = [rng.random(), rng.random()]
+        historic_samples = [
+            msprime.Sample(population=0, time=ages[i // 2]) for i in range(4)
+        ]
+        samples = samples + historic_samples
+        ts = msprime.simulate(samples=samples, mutation_rate=5, random_seed=16)
+        sample_data = tsinfer.SampleData(sequence_length=1)
+        all_times = []
+        for j in range(ts.num_samples // 2):
+            time = samples[j].time
+            sample_data.add_individual(time=time, ploidy=2)
+            all_times.append(time)
+        for variant in ts.variants():
+            sample_data.add_site(
+                variant.site.position, variant.genotypes, variant.alleles
+            )
+        sample_data.finalise()
+
+        for j, time in enumerate(sample_data.individuals_time[:]):
+            self.assertTrue(np.array_equal(all_times[j], time))
+        output_ts = tsinfer.infer(sample_data)
+        self.assertEqual(output_ts.num_individuals, len(all_times))
+        flags = output_ts.tables.nodes.flags
+        for time, individual in zip(all_times, output_ts.individuals()):
+            for node in individual.nodes:
+                if time != 0:
+                    self.assertTrue(
+                        self.assertEqual(flags[node], tsinfer.NODE_IS_HISTORIC_SAMPLE)
+                    )
+            if time != 0:
+                individual_age = (
+                    json.loads(individual).metadata["sample_data_time"].decode()
+                )
+                self.assertTrue(np.array_equal(time, individual_age))
+
 
 class TestThreads(TsinferTestCase):
     def test_equivalance(self):

--- a/tsinfer/constants.py
+++ b/tsinfer/constants.py
@@ -36,6 +36,9 @@ NODE_IS_SRB_ANCESTOR = 1 << 17
 # Bit 18 is set in node flags when they are samples inserted to augment existing
 # ancestors.
 NODE_IS_SAMPLE_ANCESTOR = 1 << 18
+# Bit 20 is set in node flags when they are samples not at time zero in the sampledata
+# file
+NODE_IS_HISTORIC_SAMPLE = 1 << 20
 
 # Marker constants for node & site time values
 TIME_UNSPECIFIED = -np.inf

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -1389,6 +1389,8 @@ class SampleMatcher(Matcher):
         for metadata in self.sample_data.populations_metadata[:]:
             tables.populations.add_row(self.encode_metadata(metadata))
         for ind in self.sample_data.individuals():
+            if ind.time != 0:
+                ind.metadata["sample_data_time"] = ind.time
             tables.individuals.add_row(
                 location=ind.location, metadata=self.encode_metadata(ind.metadata)
             )
@@ -1406,8 +1408,13 @@ class SampleMatcher(Matcher):
         samples_metadata = self.sample_data.samples_metadata[:]
         individuals_population = self.sample_data.individuals_population[:]
         samples_individual = self.sample_data.samples_individual[:]
+        individuals_time = self.sample_data.individuals_time[:]
         for index, sample_id in self.sample_id_map.items():
             individual = samples_individual[index]
+            if individuals_time[individual] != 0:
+                flags[sample_id] = np.bitwise_or(
+                    flags[sample_id], constants.NODE_IS_HISTORIC_SAMPLE
+                )
             population = individuals_population[individual]
             tables.nodes.add_row(
                 flags=flags[sample_id],


### PR DESCRIPTION
Resolves #232  and #314 

If any individuals in a `sampledata` file are historic (their time != 0), this information currently does not carry through into the inferred tree sequence. It would be very helpful for our iteration approach if it did.

If historic individuals are detected, we add two things to the resulting inferred tree sequence:
1. A new node flag, called `NODE_IS_HISTORIC_SAMPLE`, where bit 20 is set. Bits 18 and 19 will be used in #300 
2. An individual's metadata field called `sample_data_time`, where the actual time is recorded. 

I've included a roundtrip test to ensure that this carries through, I'm sure there are other good tests to write, any suggestions @hyanwong and @jeromekelleher ?