### PR TITLE
Actually reorder individuals in sd subset

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1282,14 +1282,14 @@ class TestSampleDataSubset(unittest.TestCase):
         self.assertEqual(subset.num_populations, source.num_populations)
         samples = []
         subset_inds = iter(subset.individuals())
-        for ind in source.individuals():
-            if ind.id in individuals:
-                samples.extend(ind.samples)
-                subset_ind = next(subset_inds)
-                self.assertEqual(subset_ind.time, ind.time)
-                self.assertEqual(subset_ind.location, ind.location)
-                self.assertEqual(subset_ind.metadata, ind.metadata)
-                self.assertEqual(len(subset_ind.samples), len(ind.samples))
+        for ind_id in individuals:
+            ind = source.individual(ind_id)
+            samples.extend(ind.samples)
+            subset_ind = next(subset_inds)
+            self.assertEqual(subset_ind.time, ind.time)
+            self.assertEqual(subset_ind.location, ind.location)
+            self.assertEqual(subset_ind.metadata, ind.metadata)
+            self.assertEqual(len(subset_ind.samples), len(ind.samples))
         self.assertEqual(len(samples), subset.num_samples)
 
         subset_variants = iter(subset.variants())
@@ -1322,6 +1322,16 @@ class TestSampleDataSubset(unittest.TestCase):
         G2 = np.array([v.genotypes for v in subset.variants()])
         self.assertTrue(np.array_equal(G1[rows][:, cols], G2))
         self.verify_subset_data(sd1, cols, rows)
+
+    def test_reordering_individuals(self):
+        ts = get_example_ts(10, 10, 1)
+        sd = formats.SampleData.from_tree_sequence(ts)
+        ind = np.arange(sd.num_individuals)[::-1]
+        subset = sd.subset(individuals=ind)
+        self.assertFalse(sd.data_equal(subset))
+        self.assertTrue(
+            np.array_equal(sd.sites_genotypes[:][:, ind], subset.sites_genotypes[:])
+        )
 
     def test_mixed_diploid_metadata(self):
         ts = get_example_individuals_ts_with_metadata(10, 2, 10)

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -1248,21 +1248,20 @@ class SampleData(DataContainer):
             for population in self.populations():
                 subset.add_population(population.metadata)
             sample_selection = []
-            for individual in self.individuals():
-                if individual.id in individuals:
-                    sample_selection.extend(individual.samples)
-                    samples_metadata = [
-                        all_samples_metadata[sample_id]
-                        for sample_id in individual.samples
-                    ]
-                    subset.add_individual(
-                        location=individual.location,
-                        metadata=individual.metadata,
-                        time=individual.time,
-                        population=individual.population,
-                        samples_metadata=samples_metadata,
-                        ploidy=len(samples_metadata),
-                    )
+            for individual_id in individuals:
+                individual = self.individual(individual_id)
+                sample_selection.extend(individual.samples)
+                samples_metadata = [
+                    all_samples_metadata[sample_id] for sample_id in individual.samples
+                ]
+                subset.add_individual(
+                    location=individual.location,
+                    metadata=individual.metadata,
+                    time=individual.time,
+                    population=individual.population,
+                    samples_metadata=samples_metadata,
+                    ploidy=len(samples_metadata),
+                )
             sample_selection = np.array(sample_selection, dtype=int)
             if len(sample_selection) < 2:
                 raise ValueError("Must have at least two samples")


### PR DESCRIPTION
In the docs for SampleData.subset we claim that "IDs can be supplied in any order,  and the order will be preserved in the returned data file (i.e., ``individuals[0]`` will be the first individual in the new dataset, etc)." - which is quite useful for reordering purposes. However, we never actually tested this, and it turns out that we don't preserver the order: in the original code, we loop though the order of individuals as given in the sample_data file, and check whether they are in the supplied list.

This corrects the behaviour to match the docs.