### PR TITLE
Add proxy sample ancestors to allow historic samples to be added

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,6 +21,8 @@ File formats
     3. Provide example of updating inference_sites
 
 .. autoclass:: tsinfer.AncestorData
+    :members:
+    :inherited-members:
 
 .. todo::
 

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -349,6 +349,7 @@ class DataContainer(object):
 
     def __init__(
         self,
+        *,
         path=None,
         num_flush_threads=0,
         compressor=DEFAULT_COMPRESSOR,
@@ -777,7 +778,7 @@ class Population(object):
 
 class SampleData(DataContainer):
     """
-    SampleData(sequence_length=0, path=None, num_flush_threads=0, \
+    SampleData(sequence_length=0, *, path=None, num_flush_threads=0, \
     compressor=DEFAULT_COMPRESSOR, chunk_size=1024, max_file_size=None)
 
     Class representing input sample data used for inference.
@@ -1963,7 +1964,7 @@ class Ancestor(object):
 
 class AncestorData(DataContainer):
     """
-    AncestorData(sample_data, path=None, num_flush_threads=0, compressor=None, \
+    AncestorData(sample_data, *, path=None, num_flush_threads=0, compressor=None, \
     chunk_size=1024, max_file_size=None)
 
     Class representing the stored ancestor data produced by


### PR DESCRIPTION
As discussed in #328. No tests added yet, but the code below seems to work OK. I'm opening as a draft PR so that @awohns can see if it makes sense, and works for his use case.

```
import msprime
import tsinfer
ts = msprime.simulate(10, mutation_rate=2)
sd = tsinfer.SampleData.from_tree_sequence(ts)
anc = tsinfer.generate_ancestors(sd)
new_anc = anc.insert_proxy_samples(sd, sample_ids=[1]) # NEW FUNC
ats = tsinfer.match_ancestors(sd, new_anc)
tsinfer.match_samples(sd, ats)
```