### PR TITLE
Do not simplify out populations and individuals

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 [0.2.0] - XXXX-XX-XX
 ********************
 
+**New features**:
+
 **Breaking changes**:
 
 - The ancestors tree sequence now contains the real alleles and not
@@ -11,6 +13,13 @@
 - The SampleData file no longer accepts the ``inference`` argument to add_site.
   This functionality has been replaced by the ``exclude_positions`` argument
   to the ``infer`` and ``generate_ancestors`` functions.
+
+**Bugfixes**:
+
+- Individuals and populations in the sampledata file are kept in the returned tree
+  sequence, even if they are not referenced by any sample. The individual and population
+  ids are therefore guaranteed to stay the same between the sample data file and the
+  inferred tree sequence. (:pr:`348`)
 
 ********************
 [0.1.5] - 2019-09-25

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -1528,7 +1528,7 @@ class SampleData(DataContainer):
             (haploid).
         :param dict metadata: A JSON encodable dict-like object containing
             metadata that is to be associated with this individual.
-        :param int population: The ID of the population to assoicate with this
+        :param int population: The ID of the population to associate with this
             individual (or more precisely, with the samples for this individual).
             If not specified or None, defaults to the null population (-1).
         :param arraylike location: An array-like object defining n-dimensional

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -217,7 +217,8 @@ def infer(
     :param bool simplify: Whether to remove extra tree nodes and edges that are not
         on a path between the root and any of the samples. To do so, the final tree
         sequence is simplified by appling the :meth:`tskit.TreeSequence.simplify`
-        method with ``filter_sites`` set to False and ``keep_unary`` set to True
+        method with ``filter_sites``, ``filter_populations`` and
+        ``filter_individuals`` set to False, and ``keep_unary`` set to True
         (default = ``True``).
     :param array_like exclude_positions: A list of site positions to exclude
         for full inference. Sites with these positions will not be used to generate
@@ -470,7 +471,8 @@ def match_samples(
     :param bool simplify: Whether to remove extra tree nodes and edges that are not
         on a path between the root and any of the samples. To do so, the final tree
         sequence is simplified by appling the :meth:`tskit.TreeSequence.simplify`
-        method with ``filter_sites`` set to False and ``keep_unary`` set to True
+        method with ``filter_sites``, ``filter_populations`` and
+        ``filter_individuals`` set to False and ``keep_unary`` set to True
         (default = ``True``).
     :param array_like indexes: An array of indexes into the sample_data file of
         the samples to match, or None for all samples.
@@ -1389,8 +1391,9 @@ class SampleMatcher(Matcher):
         ts = self.get_samples_tree_sequence()
         if simplify:
             logger.info(
-                "Running simplify(filter_sites=False, keep_unary=True) on"
-                f" {ts.num_nodes} nodes and {ts.num_edges} edges"
+                "Running simplify(filter_sites=False, filter_populations=False, "
+                "filter_individuals=False, keep_unary=True) on "
+                f"{ts.num_nodes} nodes and {ts.num_edges} edges"
             )
             if stabilise_node_ordering:
                 # Ensure all the node times are distinct so that they will have
@@ -1409,6 +1412,8 @@ class SampleMatcher(Matcher):
             ts = ts.simplify(
                 samples=list(self.sample_id_map.values()),
                 filter_sites=False,
+                filter_populations=False,
+                filter_individuals=False,
                 keep_unary=True,
             )
             logger.info(
@@ -1643,4 +1648,9 @@ def minimise(ts):
     sites in a tree sequence for ancestor matching. It is a thin-wrapper
     over the simplify method.
     """
-    return ts.simplify(reduce_to_site_topology=True, filter_sites=False)
+    return ts.simplify(
+        reduce_to_site_topology=True,
+        filter_sites=False,
+        filter_individuals=False,
+        filter_populations=False,
+    )


### PR DESCRIPTION
I suddenly realised that we might be changing the IDs of populations and individuals when simplifying after inference. Although I'm not sure we guarantee that the IDs remain the same between the sample_data file and the final tree sequence, I think it's good practice to avoid this.

I guess I should also add a unit test to check that the population and individual IDs in the final ts match that in the SD file?