### PR TITLE
Fix docs in from_tree_sequence()

### DIFF
--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -1377,8 +1377,7 @@ class SampleData(DataContainer):
             used if there is a single mutation at that site, in which case the node
             immediately below the mutation is taken as the origination time for the
             variant. If False, the frequency of the variant is used as a proxy for the
-            relative variant time (see :meth:`.add_site`), and all samples are set at
-            time 0.
+            relative variant time (see :meth:`.add_site`).
         :param bool use_individuals_time: If True (default), set a time for individuals
             that contain non-contemporaneous sample nodes. If False, all individuals are
             set at time 0.


### PR DESCRIPTION
Minor change in docs for from_tree_sequence(). Remove part of sentence which says that "all samples are set at time 0" if `use_sites_time=False`. This is misleading as `individuals_time` will not be set at time 0.