### PR TITLE
Use a general function for checking np object array equality

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -45,6 +45,32 @@ import tsutil
 IS_WINDOWS = sys.platform == "win32"
 
 
+class ConvenienceFunctions(unittest.TestCase):
+    """
+    Tests for a couple of convenience functions at the top level of formats.py
+    """
+
+    def test_np_obj_equal_bad(self):
+        obj_array = np.array([None])
+        self.assertRaises(AttributeError, formats.np_obj_equal, obj_array, None)
+
+    def test_np_obj_equal(self):
+        obj_array = np.array([{1, 3}, None])
+        self.assertEqual(obj_array.dtype, np.dtype("object"))
+        self.assertTrue(formats.np_obj_equal(obj_array, np.array([{1, 3}, None])))
+        for not_equal in [
+            np.array([{1, 4}, None]),
+            np.array([{1, 3}, {1, 3}]),
+            np.array([None, None]),
+            np.array([{}, {}]),
+            # Different shapes
+            np.array([[{1, 3}, None]]),
+            np.array([{1, 3}, None, None]),
+            np.array([{1, 3}]),
+        ]:
+            self.assertFalse(formats.np_obj_equal(obj_array, not_equal))
+
+
 class DataContainerMixin(object):
     """
     Common tests for the the data container classes."

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -63,6 +63,16 @@ DEFAULT_COMPRESSOR = numcodecs.Zstd()
 DEFAULT_MAX_FILE_SIZE = 2 ** 30 if sys.platform == "win32" else 2 ** 40
 
 
+def np_obj_equal(np_obj_array1, np_obj_array2):
+    """
+    A replacement for np.array_equal to test equality of numpy arrays that
+    contain objects, as used e.g. for metadata, location, alleles, etc.
+    """
+    if np_obj_array1.shape != np_obj_array2.shape:
+        return False
+    return all(itertools.starmap(np.array_equal, zip(np_obj_array1, np_obj_array2)))
+
+
 def exclude_id(attribute, value):
     """
     Used to filter out the id field from attrs objects such as Ancestor
@@ -1166,11 +1176,8 @@ class SampleData(DataContainer):
         return (
             self.num_populations == other.num_populations
             # Need to take a different approach with np object arrays.
-            and all(
-                itertools.starmap(
-                    np.array_equal,
-                    zip(self.populations_metadata[:], other.populations_metadata[:]),
-                )
+            and np_obj_equal(
+                self.populations_metadata[:], other.populations_metadata[:],
             )
         )
 
@@ -1182,19 +1189,13 @@ class SampleData(DataContainer):
             )
             and np.array_equal(self.individuals_flags[:], other.individuals_flags[:])
             and np.array_equal(
-                self.individuals_population[:], other.individuals_population[:],
+                self.individuals_population[:], other.individuals_population[:]
             )
-            and all(
-                itertools.starmap(
-                    np.array_equal,
-                    zip(self.individuals_metadata[:], other.individuals_metadata[:]),
-                )
+            and np_obj_equal(
+                self.individuals_metadata[:], other.individuals_metadata[:]
             )
-            and all(
-                itertools.starmap(
-                    np.array_equal,
-                    zip(self.individuals_location[:], other.individuals_location[:]),
-                )
+            and np_obj_equal(
+                self.individuals_location[:], other.individuals_location[:]
             )
         )
 
@@ -1202,12 +1203,7 @@ class SampleData(DataContainer):
         return (
             self.num_samples == other.num_samples
             and np.all(self.samples_individual[:] == other.samples_individual[:])
-            and all(
-                itertools.starmap(
-                    np.array_equal,
-                    zip(self.samples_metadata[:], other.samples_metadata[:]),
-                )
-            )
+            and np_obj_equal(self.samples_metadata[:], other.samples_metadata[:])
         )
 
     def sites_equal(self, other):
@@ -1216,16 +1212,8 @@ class SampleData(DataContainer):
             and np.all(self.sites_position[:] == other.sites_position[:])
             and np.all(self.sites_genotypes[:] == other.sites_genotypes[:])
             and np.allclose(self.sites_time[:], other.sites_time[:], equal_nan=True)
-            and all(
-                itertools.starmap(
-                    np.array_equal, zip(self.sites_metadata[:], other.sites_metadata[:])
-                )
-            )
-            and all(
-                itertools.starmap(
-                    np.array_equal, zip(self.sites_alleles[:], other.sites_alleles[:])
-                )
-            )
+            and np_obj_equal(self.sites_metadata[:], other.sites_metadata[:])
+            and np_obj_equal(self.sites_alleles[:], other.sites_alleles[:])
         )
 
     def data_equal(self, other):
@@ -2205,18 +2193,10 @@ class AncestorData(DataContainer):
             and np.array_equal(self.ancestors_start[:], other.ancestors_start[:])
             and np.array_equal(self.ancestors_end[:], other.ancestors_end[:])
             # Need to take a different approach with np object arrays.
-            and all(
-                itertools.starmap(
-                    np.array_equal,
-                    zip(self.ancestors_focal_sites[:], other.ancestors_focal_sites[:]),
-                )
+            and np_obj_equal(
+                self.ancestors_focal_sites[:], other.ancestors_focal_sites[:]
             )
-            and all(
-                itertools.starmap(
-                    np.array_equal,
-                    zip(self.ancestors_haplotype[:], other.ancestors_haplotype[:]),
-                )
-            )
+            and np_obj_equal(self.ancestors_haplotype[:], other.ancestors_haplotype[:])
         )
 
     @property


### PR DESCRIPTION
Simple test to be added in a moment. But I wanted to ask here: lots of these tests for equality go:

```
return (A and B and C and D)
```

where A, B, C, D are quite complicated. When these fail, it becomes really difficult to work out which of A, B, C, or D caused the failure. So I was wondering if we should switch to something like:

```
if not A:
    return False
if not B:
    return False
if not C:
    return False
if not D:
    return False
return True
```

What do you think @benjeffery ?
