### PR TITLE
Historic -> Historical

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1616,7 +1616,7 @@ class TestMinSiteTimes(unittest.TestCase):
     Test cases for sample data's min_site_times function
     """
 
-    def test_no_historic(self):
+    def test_no_historical(self):
         ts = tsutil.get_example_ts(10, 10, 1)
         sd1 = formats.SampleData.from_tree_sequence(ts)
         # No arguments and individuals_only=True should give array of zeros
@@ -1648,8 +1648,8 @@ class TestMinSiteTimes(unittest.TestCase):
         self.assertTrue(
             np.all(time_bound_individuals_only[only_younger_derived] == 0.5)
         )
-        no_historic_derived = np.all(G1[:2:4] != 1)
-        self.assertTrue(np.all(time_bound_individuals_only[no_historic_derived] == 0))
+        no_historical_derived = np.all(G1[:2:4] != 1)
+        self.assertTrue(np.all(time_bound_individuals_only[no_historical_derived] == 0))
         time_bound = sd1.min_site_times()
         self.assertTrue(np.array_equal(time_bound, sd1.sites_time[:]))
 

--- a/tsinfer/constants.py
+++ b/tsinfer/constants.py
@@ -35,7 +35,7 @@ NODE_IS_SRB_ANCESTOR = 1 << 17
 NODE_IS_SAMPLE_ANCESTOR = 1 << 18
 # Bit 20 is set in node flags when they are samples not at time zero in the sampledata
 # file
-NODE_IS_HISTORIC_SAMPLE = 1 << 20
+NODE_IS_HISTORICAL_SAMPLE = 1 << 20
 
 # What type of inference have we done at a site?
 INFERENCE_NONE = "none"

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -1358,16 +1358,16 @@ class SampleData(DataContainer):
         samples_time = self.individuals_time[:][samples_individual]
         if np.any(samples_time < 0):
             raise ValueError("Individuals cannot have negative times")
-        historic_samples = samples_time != 0
-        historic_samples_time = samples_time[historic_samples]
+        historical_samples = samples_time != 0
+        historical_samples_time = samples_time[historical_samples]
         sites_bound = np.zeros(self.num_sites)
         for var in self.variants():
-            historic_genos = var.genotypes[historic_samples]
-            derived = historic_genos > 0
+            historical_genos = var.genotypes[historical_samples]
+            derived = historical_genos > 0
             if np.any(derived):
-                historic_bound = np.max(historic_samples_time[derived])
-                if historic_bound > sites_bound[var.site.id]:
-                    sites_bound[var.site.id] = historic_bound
+                historical_bound = np.max(historical_samples_time[derived])
+                if historical_bound > sites_bound[var.site.id]:
+                    sites_bound[var.site.id] = historical_bound
         if not individuals_only:
             sites_bound = np.maximum(self.sites_time[:], sites_bound)
         return sites_bound

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -1464,7 +1464,7 @@ class SampleMatcher(Matcher):
             individual = samples_individual[index]
             if individuals_time[individual] != 0:
                 flags[sample_id] = np.bitwise_or(
-                    flags[sample_id], constants.NODE_IS_HISTORIC_SAMPLE
+                    flags[sample_id], constants.NODE_IS_HISTORICAL_SAMPLE
                 )
             population = individuals_population[individual]
             tables.nodes.add_row(


### PR DESCRIPTION
We decided a while ago to use the terminology "historical" (i.e. ancient) rather than "historic" (of major significance). A few variable names etc snuck through. This corrects them.