### PR TITLE
Use autodoc_mock_imports

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,16 +17,8 @@ import os
 import sys
 
 import pkg_resources
-from unittest.mock import MagicMock
 
-
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-        return MagicMock()
-
-
-MOCK_MODULES = [
+autodoc_mock_imports = [
     "numpy",
     "tskit",
     "_tsinfer",
@@ -38,7 +30,6 @@ MOCK_MODULES = [
     "daiquiri",
     "tqdm",
 ]
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the


### PR DESCRIPTION
I think this is how you are meant to do this now (and strangely, is the only way I could get doc compilation for tsdate working). Might it be an idea to update other tskit-dev repos, @benjeffery ?