### PR TITLE
Exclude sites if nan even after checking for unknown times

### DIFF
--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -1667,7 +1667,8 @@ class SampleData(DataContainer):
             biallelic sites this frequency should provide a reasonable estimate
             of the relative time, as used to order ancestral haplotypes during the
             inference process. For sites not used in inference, such as singletons or
-            sites with more than two alleles, the value is unused. Defaults to None.
+            sites with more than two alleles or when the time is specified as
+            ``np.nan``, then the value is unused. Defaults to None.
         :return: The ID of the newly added site.
         :rtype: int
         """


### PR DESCRIPTION
This is for discussion, but should help with a pipeline for tsdate, so it would be nice to get it in for 0.2.0. I've talked it through with @awohns , who may have some comments too.

The PR follows on from the convention that we now mark sites where freq is a proxy for time with `site_time=tskit.UNKNOWN_TIME` (which is a special form of NaN). This PR deals with the case where the `site_time` is *not* `tskit.UNKNOWN_TIME`, but some *other* form of NaN. For these sites I take it that the very meaning of a site time is nonsensical (e.g. a site where there is no variation at all). If we see such sites, it seems reasonable to me to mark them as not-for-inference, which is all that this PR does.

This gives an easy way to mark sites, during the dating process, that we know are nonsensical. It goes like this. After the first inference, we examine the tree sequence, and find the sites with huge numbers of mutations. We assume the pattern at these sites is nonsense and should be ignored. We take a copy of the tree sequence with the mutations at those sites removed, and date it using tsdate. We then extract the site times from the dated tree sequence (using the `sites_time_from_ts` tsdate function). Quite reasonably, this function marks these sites with a time of `np.nan`, because there is no variation there (it's not like an UNKNOWN_TIME, it's literally a meaningless time). We stick these times back into the *original* tree sequence, and because the nonsense sites are NaNs, they are not used for inference, but are simply stuck in using parsimony, which is what we want.

It sounds a bit convoluted, but I think the logic is solid. Basically, if there's a NaN in the time then we skip inference unless it's the very special `tskit.UNKNOWN_TIME` NaN, in which case we use time=freq.