### PR TITLE
Use Donnelly & Leslie parameterization of LS emission probs

### DIFF
--- a/tsinfer/algorithm.py
+++ b/tsinfer/algorithm.py
@@ -722,6 +722,7 @@ class AncestorMatcher:
                 assert v != -1
 
             p_last = self.likelihood[u]
+            # Stephens & Donnelly Eq 4.1
             p_no_recomb = p_last * (1 - rho + rho / n)
             p_recomb = rho / n
             recombination_required = False
@@ -731,9 +732,10 @@ class AncestorMatcher:
                 p_t = p_recomb
                 recombination_required = True
             self.traceback[site][u] = recombination_required
-            p_e = mu
+            # Stephens & Donnelly Eq 4.2, with adjustment for >2 alleles
+            p_e = mu / (num_alleles * (n + mu))
             if haplotype_state in (tskit.MISSING_DATA, self.allelic_state[v]):
-                p_e = 1 - (num_alleles - 1) * mu
+                p_e += n / (n + mu)
             self.likelihood[u] = p_t * p_e
 
             if self.likelihood[u] > max_L:


### PR DESCRIPTION
Here's my suggestion for how we should be currently parameterising mismatch, following [Donnelly & Leslie](https://arxiv.org/abs/1006.1514) eq 4.2 (see #403) I haven't touched the C code yet. I think this should go some way to fixing https://github.com/tskit-dev/tsinfer/issues/402 too, as the mismatch probability can never be 1 in this parameterisation (although I guess it can get close, if there are lots of haplotypes)