### PR TITLE
Do not include missing allele in tree seq builder num_alleles

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1142,6 +1142,28 @@ class TestSampleData(DataContainerMixin):
                         0, [0, 0], alleles=[str(x) for x in range(num_alleles)]
                     )
 
+    def test_num_alleles_with_missing(self):
+        u = tskit.MISSING_DATA
+        sites_by_samples = np.array(
+            [
+                [u, u, u, 1],
+                [u, u, u, 1],
+                [u, u, u, 1],
+                [u, 0, 0, 1],
+                [u, 0, 1, 1],
+                [u, 0, 1, 0],
+            ],
+            dtype=np.int8,
+        )
+        with tsinfer.SampleData() as sd:
+            for col in range(sites_by_samples.shape[1]):
+                genos = sites_by_samples[:, col]
+                alleles = [None if x == u else str(x) for x in np.unique(genos)]
+                if alleles[0] is None:
+                    alleles = alleles[1:] + [None]  # Put None at the end
+                sd.add_site(col, genos, alleles=alleles)
+        assert np.all(sd.num_alleles() == np.array([0, 1, 2, 2]))
+
     def test_append_sites(self):
         ts = tsutil.get_example_individuals_ts_with_metadata(4, 2, 10)
         sd1 = tsinfer.SampleData.from_tree_sequence(ts.keep_intervals([[0, 2]]))

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -1897,7 +1897,11 @@ class SampleData(DataContainer):
 
     def num_alleles(self, sites=None):
         """
-        Returns a numpy array of the number of alleles at each site.
+        Returns a numpy array of the number of alleles at each site. Missing data is
+        not counted as an allele.
+
+        :param array sites: A numpy array of sites for which to return data. If None
+            (default) return all sites.
 
         :return: A numpy array of the number of alleles at each site.
         :rtype: numpy.ndarray(dtype=uint32)
@@ -1908,6 +1912,8 @@ class SampleData(DataContainer):
         num_alleles = np.zeros(self.num_sites, dtype=np.uint32)
         for j, alleles in enumerate(alleles):
             num_alleles[j] = len(alleles)
+            if alleles[-1] is None:
+                num_alleles[j] -= 1
         return num_alleles[sites]
 
     def variants(self, sites=None):


### PR DESCRIPTION
Fixes #406 and addresses https://github.com/tskit-dev/tsinfer/issues/403#issuecomment-741846467 about counting missing data as an allele.

I'm slightly tempted to default to "count_missing=False", but this would not be backward compatible. OTOH, I'm not sure the missing data stuff has been previously released anyway. What do you think @jeromekelleher ?