### PR TITLE
Temporarily remove references to RateMap

### DIFF
--- a/docs/inference.rst
+++ b/docs/inference.rst
@@ -180,7 +180,7 @@ distribution of variation to fit poorly to the marginal tree at that site.
 Hence, if there is error in your dataset, you may wish to experiment with
 these settings to obtain optimal results.
 
-The ``recombination_rate`` parameter can be a RateMap object, or a floating
+The ``recombination_rate`` parameter is a floating
 point value giving a single rate (:math:`\rho`) across the entire sequence.
 This can be used to calculate the genetic distance between sites, which in turn
 can be used to derive an array of probabilities of recombination between

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -233,13 +233,13 @@ def infer(
 
     :param SampleData sample_data: The input :class:`SampleData` instance
         representing the observed data that we wish to make inferences from.
-    :param recombination_rate: Either a RateMap object, or a floating
+    :param recombination_rate: A floating
         point value giving a single rate, :math:`\\rho`, across the entire sequence,
         used to calculate the probability of recombination between adjacent sites.
         If ``None``, all matching conflicts are resolved by recombination and
         all inference sites will have a single mutation (equivalent to mismatch_ratio
         near zero)
-    :type recombination_rate: Union[float, RateMap]
+    :type recombination_rate: float
     :param float mismatch_ratio: The probability of a mismatch relative to the median
         probability of recombination between adjacent sites: can only be used if a
         recombination rate has been set (default: 1)
@@ -401,13 +401,13 @@ def match_ancestors(
     :param AncestorData ancestor_data: The :class:`AncestorData` instance
         representing the set of ancestral haplotypes for which we are finding
         a history.
-    :param recombination_rate: Either a RateMap object, or a floating
+    :param recombination_rate: A floating
         point value giving a single rate, :math:`\\rho`, across the entire sequence,
         used to calculate the probability of recombination between adjacent sites.
         If ``None``, all matching conflicts are resolved by recombination and
         all inference sites will have a single mutation (equivalent to mismatch_ratio
         near zero)
-    :type recombination_rate: Union[float, RateMap]
+    :type recombination_rate: float
     :param float mismatch_ratio: The probability of a mismatch relative to the median
         probability of recombination between adjacent sites: can only be used if a
         recombination rate has been set (default: 1)
@@ -477,13 +477,13 @@ def augment_ancestors(
         history among ancestral ancestral haplotypes.
     :param array indexes: The sample indexes to insert into the ancestors
         tree sequence.
-    :param recombination_rate: Either a RateMap object, or a floating
+    :param recombination_rate: A floating
         point value giving a single rate, :math:`\\rho`, across the entire sequence,
         used to calculate the probability of recombination between adjacent sites.
         If ``None``, all matching conflicts are resolved by recombination and
         all inference sites will have a single mutation (equivalent to mismatch_ratio
         near zero)
-    :type recombination_rate: Union[float, RateMap]
+    :type recombination_rate: float
     :param float mismatch_ratio: The probability of a mismatch relative to the median
         probability of recombination between adjacent sites: can only be used if a
         recombination rate has been set (default: 1)
@@ -558,13 +558,13 @@ def match_samples(
     :param tskit.TreeSequence ancestors_ts: The
         :class:`tskit.TreeSequence` instance representing the inferred
         history among ancestral ancestral haplotypes.
-    :param recombination_rate: Either a RateMap object, or a floating
+    :param recombination_rate: A floating
         point value giving a single rate, :math:`\\rho`, across the entire sequence,
         used to calculate the probability of recombination between adjacent sites.
         If ``None``, all matching conflicts are resolved by recombination and
         all inference sites will have a single mutation (equivalent to mismatch_ratio
         near zero)
-    :type recombination_rate: Union[float, RateMap]
+    :type recombination_rate: float
     :param float mismatch_ratio: The probability of a mismatch relative to the median
         probability of recombination between adjacent sites: can only be used if a
         recombination rate has been set (default: 1)


### PR DESCRIPTION
Needed before release 0.2 (see #430). This undocuments the passing of RateMap as a recombination_rate parameter. We still allow it to be used, so that @awohns can use tsinfer 0.2 as the basis of his analyses. The idea is to revert this PR when msprime 1.0 alpha is released.