### PR TITLE
changelog should say times stored as tskit.UNKNOWN_TIME

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,7 +36,8 @@ Major feature release, including some incompatible file format and API updates.
   0/1 values as before.
 
 - Times for undated sites now use frequencies (0..1), not as counts (1..num_samples),
-  and are now stored as -inf, then calculated on the fly in the variants() iterator.
+  and are now stored as ``tskit.UNKNOWN_TIME``, then calculated on the fly in the
+  variants() iterator.
 
 - The SampleData file no longer accepts the ``inference`` argument to add_site.
   This functionality has been replaced by the ``exclude_positions`` argument


### PR DESCRIPTION
Sorry @jeromekelleher  - missed this on the first review of your changelog commits