### PR TITLE
Account for change in tskit individuals.add_row

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -193,7 +193,7 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "https://docs.python.org/3/": None,
-    "https://tskit.readthedocs.io/en/latest/": None,
+    "https://tskit.dev/tskit/docs/stable": None,
     "https://numcodecs.readthedocs.io/en/stable/": None,
     "https://zarr.readthedocs.io/en/stable/": None,
 }

--- a/tests/tsutil.py
+++ b/tests/tsutil.py
@@ -105,7 +105,9 @@ def get_example_individuals_ts_with_metadata(
             pop_meta = {"utf": chr(127462) + chr(127462 + i)}
         tables.populations.add_row(metadata=pop_meta)  # One pop for each individual
         if i < n - 1 or not skip_last:
-            tables.individuals.add_row(individual_flags, location, individual_meta)
+            tables.individuals.add_row(
+                flags=individual_flags, location=location, metadata=individual_meta
+            )
 
     node_populations = tables.nodes.population
     for node in ts.nodes():


### PR DESCRIPTION
As of tskit 0.3.5 there is now an extra param in `individuals.add_row`, so we need to switch to named parameters to get tests to pass.