### PR TITLE
Use dependency levels rather than epochs

### DIFF
--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -2546,16 +2546,20 @@ class AncestorData(DataContainer):
     # Read mode
     ####################################
 
-    def ancestors(self):
+    def ancestors(self, indexes=None):
         """
-        Returns an iterator over all the ancestors.
+        Returns an iterator over all the ancestors. If indexes is provided, it should
+        be a sorted list of indexes giving a subset of ancestors to return.
+        For efficiency, the indexes should be a numpy integer array.
         """
-        # TODO document properly.
         start = self.ancestors_start[:]
         end = self.ancestors_end[:]
         time = self.ancestors_time[:]
         focal_sites = self.ancestors_focal_sites[:]
-        for j, h in enumerate(chunk_iterator(self.ancestors_haplotype)):
+        haplotypes = chunk_iterator(self.ancestors_haplotype, indexes)
+        if indexes is None:
+            indexes = range(len(time))
+        for j, h in zip(indexes, haplotypes):
             yield Ancestor(
                 id=j,
                 start=start[j],


### PR DESCRIPTION
OMG @jeromekelleher . I think this might actually work to address #147 . It's only failing on 3 tests, all of them when doing `self.tree_sequence_builder.add_path()`, with the following failure

```
_tsinfer.LibraryError: Bad path information: time
```

I suspect that's because `add_path()` is checking that stuff is added in time order, but it probably doesn't need to? Perhaps you could take a quick look to confirm. Then I can try perf testing this!!!