### PR TITLE
Remove .egg dir on make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,4 @@ ctags:
 clean:
 	rm -f *.so *.o tags
 	rm -fR build
+	rm -fR .eggs


### PR DESCRIPTION
It seems as if when I now compile tsinfer it puts stuff in the .egg dir, and then I have to clear it out to remake. I *think* adding it to `make clean` is therefore correct: is that right @benjeffery ?