### PR TITLE
Fixes https://github.com/tskit-dev/tsinfer/discussions/523#discussion…

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -397,7 +397,7 @@ variants from chromosome 24 of ten Norwegian and French house sparrows,
                 for row in variant.genotypes
                 for old_index in row[0:2]
             ]
-            samples.add_site(pos, genotypes=genotypes, alleles=alleles)
+            samples.add_site(pos, genotypes=genotypes, alleles=ordered_alleles)
 
 
     def chromosome_length(vcf):


### PR DESCRIPTION
…comment-880019

I'm pretty sure this is a bug in the example VCF reading code and should be corrected ASAP. @awohns - you presumably didn't use this code for reading in any important VCFs did you: it looks to me as if we might be accidentally flipping allelic states when the ancestral allele is not the ref. Erk. Could you check that (a) the fix is the correct one and (b) it's not caused any cock-ups for our analyses?

Sorry about that.
