### PR TITLE
Switch to the (more correct) new map_mutations code

### DIFF
--- a/requirements/CI-tests-complete/requirements.txt
+++ b/requirements/CI-tests-complete/requirements.txt
@@ -16,5 +16,5 @@ pytest-xdist==2.2.1
 seaborn==0.11.1
 sortedcontainers==2.3.0
 tqdm==4.60.0
-tskit==0.3.5
+tskit==0.3.7
 zarr==2.8.1

--- a/requirements/CI-tests-pip/requirements.txt
+++ b/requirements/CI-tests-pip/requirements.txt
@@ -10,4 +10,4 @@ pytest-xdist==2.2.1
 seaborn==0.11.1
 sortedcontainers==2.3.0
 tqdm==4.61.1
-tskit==0.3.6
+tskit==0.3.7

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         "tqdm",
         "humanize",
         "daiquiri",
-        "tskit>=0.3.3",
+        "tskit>=0.3.7",
         "numcodecs>=0.6",
         "zarr>=2.2",
         "lmdb",


### PR DESCRIPTION
This allows ancestral states to be correctly set, but will only work once a version of tskit > 0.3.6 is released with PR https://github.com/tskit-dev/tskit/pull/1550 merged