### PR TITLE
Downgrade h5py to fix conda version conflict

### DIFF
--- a/requirements/CI-tests-conda/requirements.txt
+++ b/requirements/CI-tests-conda/requirements.txt
@@ -2,4 +2,4 @@ lmdb==0.9.24
 msprime==1.0.2
 python-lmdb==0.96
 zarr==2.10.0
-h5py==3.3.0
+h5py<3.2


### PR DESCRIPTION
I think our CI is hitting this:https://github.com/conda-forge/h5py-feedstock/issues/92