### PR TITLE
Change time defaults for from_tree_sequence

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@
 - Oldest nodes in a standard inferred tree sequence are no longer set to frequencies ~2
   and ~3 (i.e. 2 or 3 times as old as all the other nodes), but are spaced above the
   others by the mean time between unique ancestor ages (:pr:`485`, :user:`hyanwong`)
+  
+- The ``tsinfer.SampleData.from_tree_sequence()`` function now defaults to setting
+  ``use_sites_time`` and ``use_individuals_time`` to ``False`` rather than ``True``
+  (:pr:`599`, :user:`hyanwong`)
 
 ********************
 [0.2.1] - 2021-05-26

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1116,7 +1116,11 @@ class TestMetadataRoundTrip:
         seq_len = 10
         individual_times = np.arange(n_indiv)
         ts = tsutil.get_example_historical_sampled_ts(individual_times, ploidy, seq_len)
-        ts_inferred = tsinfer.infer(tsinfer.SampleData.from_tree_sequence(ts))
+        ts_inferred = tsinfer.infer(
+            tsinfer.SampleData.from_tree_sequence(
+                ts, use_sites_time=True, use_individuals_time=True
+            )
+        )
         assert ts.sequence_length == ts_inferred.sequence_length
         assert ts.metadata_schema == ts_inferred.metadata_schema
         assert ts.metadata == ts_inferred.metadata


### PR DESCRIPTION
As in discussions with @awohns and @jeromekelleher. Note that we now error out, saying "Incompatible timescales" if we are using times as freqs, but have historical samples. The workaround if a user really does want to do this (which is unlikely, I think: it would imply that the historical samples were placed at times equivalent to the frequencies of alleles) is to set the site times manually.