### PR TITLE
Test suite to use new msprime calling convention

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -193,6 +193,7 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "https://docs.python.org/3/": None,
+    "https://tskit.dev/tutorials": None,
     "https://tskit.dev/tskit/docs/stable": None,
     "https://tskit.dev/msprime/docs/stable": None,
     "https://numcodecs.readthedocs.io/en/stable/": None,

--- a/requirements/CI-tests-complete/requirements.txt
+++ b/requirements/CI-tests-complete/requirements.txt
@@ -16,5 +16,5 @@ pytest-xdist==2.2.1
 seaborn==0.11.1
 sortedcontainers==2.3.0
 tqdm==4.60.0
-tskit==0.3.7
+tskit==0.4.1
 zarr==2.10.3

--- a/requirements/CI-tests-pip/requirements.txt
+++ b/requirements/CI-tests-pip/requirements.txt
@@ -10,4 +10,4 @@ pytest-xdist==2.4.0
 seaborn==0.11.2
 sortedcontainers==2.4.0
 tqdm==4.62.3
-tskit==0.3.7
+tskit==0.4.1

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,3 +1,4 @@
+attrs
 codecov
 coverage
 flake8
@@ -7,9 +8,9 @@ tqdm
 humanize
 daiquiri
 msprime >= 1.0.0
+tskit >= 0.4.1
 zarr<2.11.0
 lmdb
-attrs
 pytest
 pytest-xdist
 pytest-coverage

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1079,9 +1079,8 @@ class TestMetadataRoundTrip:
         """
         n_indiv = 5
         ploidy = 2  # Diploids
-        seq_len = 10
         ts = tsutil.get_example_individuals_ts_with_metadata(
-            n_indiv, ploidy, seq_len, 1, skip_last=False
+            n_indiv, ploidy, skip_last=False
         )
         ts_inferred = tsinfer.infer(tsinfer.SampleData.from_tree_sequence(ts))
         assert ts.sequence_length == ts_inferred.sequence_length
@@ -1113,9 +1112,8 @@ class TestMetadataRoundTrip:
         """
         n_indiv = 5
         ploidy = 2  # Diploids
-        seq_len = 10
         individual_times = np.arange(n_indiv)
-        ts = tsutil.get_example_historical_sampled_ts(individual_times, ploidy, seq_len)
+        ts = tsutil.get_example_historical_sampled_ts(individual_times, ploidy)
         ts_inferred = tsinfer.infer(
             tsinfer.SampleData.from_tree_sequence(
                 ts, use_sites_time=True, use_individuals_time=True

--- a/tests/tsutil.py
+++ b/tests/tsutil.py
@@ -120,6 +120,7 @@ def get_example_individuals_ts_with_metadata(
     tables.metadata = {f"a_{j}": j for j in range(n)}
     tables.populations.clear()
     tables.individuals.clear()
+    rng = np.random.default_rng(123)
     for i in range(n):
         location = [i, i]
         individual_meta = {}
@@ -127,7 +128,7 @@ def get_example_individuals_ts_with_metadata(
         if i % 2 == 0:
             # Add unicode metadata to every other individual: 8544+i = Roman numerals
             individual_meta = {"unicode id": chr(8544 + i)}
-            individual_flags = np.random.randint(0, np.iinfo(np.uint32).max)
+            individual_flags = rng.integers(0, np.iinfo(np.uint32).max, dtype=np.int64)
             # Also for populations: chr(127462) + chr(127462+i) give emoji flags
             pop_meta = {"utf": chr(127462) + chr(127462 + i)}
         tables.populations.add_row(metadata=pop_meta)  # One pop for each individual


### PR DESCRIPTION
Ideally we should switch to the new msprime for testing, since it has discrete genome coords, individuals, metadata, etc. This switches the tree sequences used for testing to new format versions