### PR TITLE
Remove the ultimate ancestor and split the grand MRCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
 
 **Breaking changes**:
 
+- The ``simplify`` parameter is now deprecated in favour of ``post_process``, which
+  prior to simplification, removes the "virtual-root-like" ancestor (inserted by
+  tsinfer to aid the matching process) then splits the grand MRCA into separate pieces.
+  If splitting is not required, the ``post_process`` step can also be called as a
+  separate function with the parameter ``split_mrca=False`` (:pr:`687`,
+  :issue:`673`, :user:`hyanwong`) 
+  
+
 - Inference now sets time_units on both ancestor and final tree sequences to
   tskit.TIME_UNITS_UNCALIBRATED, stopping accidental use of branch length
   calculations on the ts. ({pr}`680`, {user}`hyanwong`)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -55,6 +55,8 @@ Running inference
 
 .. autofunction:: tsinfer.augment_ancestors
 
+.. autofunction:: tsinfer.post_process
+
 **********
 Exceptions
 **********

--- a/requirements/CI-tests-complete/requirements.txt
+++ b/requirements/CI-tests-complete/requirements.txt
@@ -16,5 +16,5 @@ pytest-xdist==2.5.0
 seaborn==0.11.2
 sortedcontainers==2.4.0
 tqdm==4.64.0
-tskit==0.5.0
+tskit==0.5.3
 zarr==2.11.3

--- a/requirements/CI-tests-pip/requirements.txt
+++ b/requirements/CI-tests-pip/requirements.txt
@@ -10,5 +10,5 @@ pytest-xdist==2.5.0
 seaborn==0.11.2
 sortedcontainers==2.4.0
 tqdm==4.64.0
-tskit==0.5.0
+tskit==0.5.3
 zarr==2.11.3

--- a/requirements/CI-tests-pip/requirements3.7.txt
+++ b/requirements/CI-tests-pip/requirements3.7.txt
@@ -10,5 +10,5 @@ pytest-xdist==2.5.0
 seaborn==0.11.2
 sortedcontainers==2.4.0
 tqdm==4.64.0
-tskit==0.4.1
+tskit==0.5.3
 zarr==2.11.3

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -8,7 +8,7 @@ tqdm
 humanize
 daiquiri
 msprime >= 1.0.0
-tskit >= 0.4.1
+tskit >= 0.5.3
 zarr!=2.11.0, !=2.11.1, !=2.11.2
 lmdb
 pytest

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         "tqdm",
         "humanize",
         "daiquiri",
-        "tskit>=0.5.0",
+        "tskit>=0.5.3",
         "numcodecs>=0.6",
         # issues 965 and 967 at zarr-python prevent usage of 2.11.0 and 2.11.1
         "zarr>=2.2,!=2.11.0,!=2.11.1,!=2.11.2",


### PR DESCRIPTION
In a [few](https://github.com/tskit-dev/tsinfer/issues/649#issuecomment-1143628417) [issues](https://github.com/tskit-dev/tsinfer/issues/275#issuecomment-1065012704) we decided to remove the "ultimate" ancestors (the hack that means that the ancestors IDs in the ancestors file and the tree sequence align. This is needed as a precursor to #673.

This does this, removing the assert, but on my laptop I'm finding this now fails in unexpected ways in find_path etc, which makes me think that we are removing one of the ancestors required for LS matching.