### PR TITLE
Remove an unused parameter from make_ancestors_ts

### DIFF
--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -529,9 +529,7 @@ class TestMakeAncestorsTs:
 
     def verify_from_source(self, ts, remove_leaves):
         samples = tsinfer.SampleData.from_tree_sequence(ts, use_sites_time=False)
-        ancestors_ts = tsinfer.make_ancestors_ts(
-            samples, ts, remove_leaves=remove_leaves
-        )
+        ancestors_ts = tsinfer.make_ancestors_ts(ts, remove_leaves=remove_leaves)
         tsinfer.check_ancestors_ts(ancestors_ts)
         for engine in [tsinfer.PY_ENGINE, tsinfer.C_ENGINE]:
             final_ts = tsinfer.match_samples(samples, ancestors_ts, engine=engine)
@@ -546,9 +544,7 @@ class TestMakeAncestorsTs:
         ts = msprime.simulate(15, recombination_rate=1, mutation_rate=2, random_seed=3)
         samples = tsinfer.SampleData.from_tree_sequence(ts)
         inferred = tsinfer.infer(samples)
-        ancestors_ts = tsinfer.make_ancestors_ts(
-            samples, inferred, remove_leaves=remove_leaves
-        )
+        ancestors_ts = tsinfer.make_ancestors_ts(inferred, remove_leaves=remove_leaves)
         tsinfer.check_ancestors_ts(ancestors_ts)
         for engine in [tsinfer.PY_ENGINE, tsinfer.C_ENGINE]:
             final_ts = tsinfer.match_samples(samples, ancestors_ts, engine=engine)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1788,7 +1788,7 @@ class TestAncestorsTreeSequenceIndividuals:
                 samples.add_individual(ploidy=2, location=[100 * j], metadata={"X": j})
             for var in ts.variants():
                 samples.add_site(var.site.position, var.genotypes)
-        ancestors_ts = eval_util.make_ancestors_ts(samples, ts)
+        ancestors_ts = eval_util.make_ancestors_ts(ts)
         self.verify(samples, ancestors_ts)
 
 

--- a/tsinfer/eval_util.py
+++ b/tsinfer/eval_util.py
@@ -440,11 +440,11 @@ def subset_sites(ts, position):
     return tables.tree_sequence()
 
 
-def make_ancestors_ts(samples, ts, remove_leaves=False):
+def make_ancestors_ts(ts, remove_leaves=False):
     """
     Return a tree sequence suitable for use as an ancestors tree sequence from the
-    specified source tree sequence using the samples in the specified sample
-    data. If remove_leaves is True, remove any nodes that are at time zero.
+    specified source tree sequence. If remove_leaves is True, remove any nodes that
+    are at time zero.
 
     We generally assume that this is a standard tree sequence, as output by
     msprime.simulate. We remove populations, as normally ancestors tree sequences
@@ -693,7 +693,7 @@ def run_perfect_inference(
     if use_ts:
         # Use the actual tree sequence that was provided as the basis for copying.
         logger.info("Using provided tree sequence")
-        ancestors_ts = make_ancestors_ts(sample_data, ts, remove_leaves=True)
+        ancestors_ts = make_ancestors_ts(ts, remove_leaves=True)
     else:
         ancestor_data = formats.AncestorData(sample_data)
         build_simulated_ancestors(


### PR DESCRIPTION
make_ancestors_ts is not exposed, but it's still confusing to have a param that is never used.