### PR TITLE
Switch to the default tskit permissive JSON schema

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1304,6 +1304,16 @@ class TestSampleData(DataContainerMixin):
 
 
 class TestSampleDataMetadataSchemas:
+    def test_non_json_metadata_schema(self):
+        with formats.SampleData() as sample_data:
+            sample_data.add_site(0, [0, 0])
+            with pytest.raises(ValueError, match="Only the JSON codec"):
+                sample_data.metadata_schema = {
+                    "codec": "struct",
+                    "properties": {},
+                    "type": "object",
+                }
+
     def test_metadata_schemas_default(self):
         with formats.SampleData() as sample_data:
             sample_data.add_site(0, [0, 0])

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1318,13 +1318,13 @@ class TestSampleDataMetadataSchemas:
         bad_schema["codec"] = "struct"
         with formats.SampleData() as sample_data:
             sample_data.add_site(0, [0, 0])
-            with pytest.raises(KeyError):
+            with pytest.raises(BaseException):
                 sample_data.metadata_schema = bad_schema
-            with pytest.raises(KeyError):
+            with pytest.raises(BaseException):
                 sample_data.populations_metadata_schema = bad_schema
-            with pytest.raises(KeyError):
+            with pytest.raises(BaseException):
                 sample_data.individuals_metadata_schema = bad_schema
-            with pytest.raises(KeyError):
+            with pytest.raises(BaseException):
                 sample_data.sites_metadata_schema = bad_schema
 
     def test_set_top_level_metadata_schema(self):

--- a/tests/tsutil.py
+++ b/tests/tsutil.py
@@ -25,8 +25,6 @@ import msprime
 import numpy as np
 import tskit
 
-import tsinfer
-
 
 def mark_mutation_times_unknown(ts):
     """
@@ -47,7 +45,7 @@ def add_default_schemas(ts):
     schemas on the tables that are used for round-tripping data in tsinfer.
     """
     tables = ts.dump_tables()
-    schema = tskit.MetadataSchema(tsinfer.permissive_json_schema())
+    schema = tskit.MetadataSchema.permissive_json()
     assert len(tables.metadata) == 0
     tables.metadata_schema = schema
     tables.metadata = {}

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -64,18 +64,6 @@ DEFAULT_COMPRESSOR = numcodecs.Zstd()
 DEFAULT_MAX_FILE_SIZE = 2**30 if sys.platform == "win32" else 2**40
 
 
-def permissive_json_schema():
-    # A version of this should be in tskit, but we keep it here for now
-    # for convenience
-    return {
-        "codec": "json",
-        "type": "object",
-        "properties": {},
-        "required": [],
-        "additionalProperties": True,
-    }
-
-
 def np_obj_equal(np_obj_array1, np_obj_array2):
     """
     A replacement for np.array_equal to test equality of numpy arrays that
@@ -964,7 +952,9 @@ class SampleData(DataContainer):
         super().__init__(**kwargs)
         self.data.attrs["sequence_length"] = float(sequence_length)
         self.data.attrs["metadata"] = {}
-        self.data.attrs["metadata_schema"] = permissive_json_schema()
+        self.data.attrs[
+            "metadata_schema"
+        ] = tskit.MetadataSchema.permissive_json().schema
         chunks = (self._chunk_size,)
         populations_group = self.data.create_group("populations")
         metadata = populations_group.create_dataset(

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -82,6 +82,8 @@ def add_to_schema(schema, name, definition=None, required=False):
         schema["properties"] = {}
     schema["properties"][name] = definition
     if required:
+        if "required" not in schema:
+            schema["required"] = []
         schema["required"].append(name)
     return schema
 


### PR DESCRIPTION
Fixes #694. Note that the error type has now changed from `ValueError` to `KeyError` when trying to access a badly formed struct schema, here:

https://github.com/tskit-dev/tsinfer/blob/7079672f91e4e4306ef0a644016ce041c3ca9e97/tests/test_formats.py#L1282

we now get 

```
    def required_validator(validator, required, instance, schema):
        # Do the normal validation
        yield from jsonschema._validators.required(validator, required, instance, schema)
    
        # For struct codec if a property is not required, then it must have a default
>       for prop, sub_schema in instance["properties"].items():
E       KeyError: 'properties'
```

I guess that's fine, though?