### PR TITLE
Delete topology in flanking regions

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -1692,11 +1692,13 @@ def run_ancestor_quality(args):
 def get_node_degree_by_depth(ts):
     """
     Returns a tuple (degree, depth) for each node in each tree in the
-    specified tree sequence.
+    specified tree sequence (empty flanking regions are omitted)
     """
     degree = []
     depth = []
     for tree in ts.trees():
+        if tree.num_edges == 0 and (tree.index == 0 or tree.index == ts.num_trees - 1):
+            continue
         stack = [(tree.root, 0)]
         while len(stack) > 0:
             u, d = stack.pop()

--- a/tsinfer/eval_util.py
+++ b/tsinfer/eval_util.py
@@ -776,9 +776,14 @@ def node_span(ts):
             for u in [edge.parent, edge.child]:
                 if start[u] == -1 and tree.num_samples(u) > 0:
                     start[u] = left
+    # add intervals for the last tree
     for u in tree.nodes():
         if tree.num_samples(u) > 0:
             S[u] += ts.sequence_length - start[u]
+    # isolated sample nodes (e.g. where topology was deleted) will have been missed when
+    # iterating over edges, but by definition they span the entire ts, so override them
+    for u in ts.samples():
+        S[u] = ts.sequence_length
     return S
 
 


### PR DESCRIPTION
Fixes #483. I have added an option to `post_process` not to do this, partially because it makes testing easier. But there's no way to skip the flanking topology deletion unless you call post_process explicitly.