### PR TITLE
Add --no-post-process as an alias

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -293,9 +293,25 @@ class TestMatchSamples(TestCli):
         output_trees_no_simplify = os.path.join(
             self.tempdir.name, "output-nosimplify.trees"
         )
+        output_trees_no_post_process = os.path.join(
+            self.tempdir.name, "output-nopostprocess.trees"
+        )
         self.run_command(["generate-ancestors", self.sample_file])
         self.run_command(["match-ancestors", self.sample_file])
         self.run_command(["match-samples", self.sample_file, "-O", output_trees])
+        self.run_command(
+            [
+                "match-samples",
+                self.sample_file,
+                "--no-post-process",
+                "-O",
+                output_trees_no_post_process,
+            ]
+        )
+        t1 = tskit.load(output_trees).tables
+        t2 = tskit.load(output_trees_no_post_process).tables
+        assert t1.nodes != t2.nodes
+        # --no-simplify is an alias
         self.run_command(
             [
                 "match-samples",
@@ -305,9 +321,8 @@ class TestMatchSamples(TestCli):
                 output_trees_no_simplify,
             ]
         )
-        t1 = tskit.load(output_trees).tables
-        t2 = tskit.load(output_trees_no_simplify).tables
-        assert t1.nodes != t2.nodes
+        t3 = tskit.load(output_trees_no_simplify).tables
+        assert t2.nodes == t3.nodes
 
 
 class TestList(TestCli):

--- a/tsinfer/cli.py
+++ b/tsinfer/cli.py
@@ -218,7 +218,7 @@ def run_match_samples(args):
         ancestors_trees,
         num_threads=args.num_threads,
         path_compression=not args.no_path_compression,
-        simplify=not args.no_simplify,
+        post_process=not args.no_post_process,
         progress_monitor=args.progress,
     )
     logger.info(f"Writing output tree sequence to {output_trees}")
@@ -302,11 +302,12 @@ def add_path_compression_argument(parser):
     )
 
 
-def add_simplify_argument(parser):
+def add_postprocess_argument(parser):
     parser.add_argument(
-        "--no-simplify",
+        "--no-post-process",
+        "--no-simplify",  # Deprecated alias
         action="store_true",
-        help="Do not simplify the output tree sequence",
+        help="Do not post process the output tree sequence",
     )
 
 
@@ -434,7 +435,7 @@ def get_cli_parser():
     add_logging_arguments(parser)
     add_ancestors_trees_argument(parser)
     add_path_compression_argument(parser)
-    add_simplify_argument(parser)
+    add_postprocess_argument(parser)
     add_output_trees_argument(parser)
     add_num_threads_argument(parser)
     add_progress_argument(parser)


### PR DESCRIPTION
This is the simplest way to fix https://github.com/tskit-dev/tsinfer/issues/721, although it doesn't tell the user that the `--no-simplify` option is deprecated. However, it does save hassle working out what to do when conflicting options are passed, etc.