### PR TITLE
Release traceback memory if gets > 2GiB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: tsinfer-{{ .Branch }}
+          key: tsinfer-{{ .Branch }}-v1
 
       - run:
           name: Install dependencies and set PATH
@@ -24,7 +24,7 @@ jobs:
               pip install -r requirements/CI-tests-complete/requirements.txt --user
 
       - save_cache:
-          key: tsinfer-{{ .Branch }}
+          key: tsinfer-{{ .Branch }}-v1
           paths:
             - "/home/circleci/.local"
 
@@ -105,9 +105,9 @@ jobs:
             source venv/bin/activate
             pip install dist/*.tar.gz
             python -c 'import tsinfer; print(tsinfer.__version__)'
-            
+
             #Also check the wheel
             pip uninstall --yes tsinfer
             pip install dist/*.whl
             python -c 'import tsinfer; print(tsinfer.__version__)'
-            
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 In development
 
+**Performance improvements**
+
+- Reduce memory usage when running `match_samples` against large cohorts 
+  containing sequences with substantial amounts of error. 
+  ({pr}`761`, {user}`jeromekelleher`)
+
 ## [0.3.0] - 2022-10-25
 
 **Features**

--- a/lib/ancestor_matcher.c
+++ b/lib/ancestor_matcher.c
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 #include <math.h>
 
+
 static inline bool
 is_nonzero_root(const tsk_id_t u, const tsk_id_t *restrict parent,
     const tsk_id_t *restrict left_child)
@@ -106,8 +107,6 @@ ancestor_matcher_alloc(ancestor_matcher_t *self,
     double *mismatch_rate, unsigned int precision, int flags)
 {
     int ret = 0;
-    /* TODO make these input parameters. */
-    size_t traceback_block_size = 64 * 1024 * 1024;
 
     memset(self, 0, sizeof(ancestor_matcher_t));
     /* All allocs for arrays related to nodes are done in expand_nodes */
@@ -132,7 +131,12 @@ ancestor_matcher_alloc(ancestor_matcher_t *self,
         ret = TSI_ERR_NO_MEMORY;
         goto out;
     }
-    ret = tsk_blkalloc_init(&self->traceback_allocator, traceback_block_size);
+    /* Alloc in 64MiB blocks. */
+    self->traceback_block_size = 64 * 1024 * 1024;
+    /* If the traceback allocator is using more than 2GiB of RAM free it, so
+     * that other threads can use the memory */
+    self->traceback_realloc_size = 2L * 1024L * 1024L * 1024L;
+    ret = tsk_blkalloc_init(&self->traceback_allocator, self->traceback_block_size);
     if (ret != 0) {
         goto out;
     }
@@ -553,9 +557,18 @@ ancestor_matcher_reset(ancestor_matcher_t *self)
     assert(self->num_nodes <= self->max_nodes);
 
     memset(self->allelic_state, 0xff, self->num_nodes * sizeof(*self->allelic_state));
-    ret = tsk_blkalloc_reset(&self->traceback_allocator);
-    if (ret != 0) {
-        goto out;
+
+    if (self->traceback_allocator.total_size > self->traceback_realloc_size) {
+        tsk_blkalloc_free(&self->traceback_allocator);
+        ret = tsk_blkalloc_init(&self->traceback_allocator, self->traceback_block_size);
+        if (ret != 0) {
+            goto out;
+        }
+    } else {
+        ret = tsk_blkalloc_reset(&self->traceback_allocator);
+        if (ret != 0) {
+            goto out;
+        }
     }
     self->total_traceback_size = 0;
     self->num_likelihood_nodes = 0;

--- a/lib/ancestor_matcher.c
+++ b/lib/ancestor_matcher.c
@@ -26,7 +26,6 @@
 #include <stdbool.h>
 #include <math.h>
 
-
 static inline bool
 is_nonzero_root(const tsk_id_t u, const tsk_id_t *restrict parent,
     const tsk_id_t *restrict left_child)

--- a/lib/tests/tests.c
+++ b/lib/tests/tests.c
@@ -555,6 +555,9 @@ test_matching_one_site(void)
     ret = tree_sequence_builder_freeze_indexes(&tsb);
     CU_ASSERT_EQUAL_FATAL(ret, 0);
 
+    /* Make sure we hit the realloc behaviour on the ancestor matcher */
+    ancestor_matcher.traceback_realloc_size = 10;
+
     ret = ancestor_matcher_find_path(
         &ancestor_matcher, 0, 1, haplotype, match, &num_edges, &left, &right, &parent);
     CU_ASSERT_EQUAL_FATAL(ret, 0);

--- a/lib/tsinfer.h
+++ b/lib/tsinfer.h
@@ -186,6 +186,8 @@ typedef struct {
     node_state_list_t *traceback;
     tsk_blkalloc_t traceback_allocator;
     size_t total_traceback_size;
+    size_t traceback_block_size;
+    size_t traceback_realloc_size;
     struct {
         tsk_id_t *left;
         tsk_id_t *right;


### PR DESCRIPTION
Otherwise many threads will end up with very large allocations as sequences that result in large tracebacks are randomly assigned to different threads.