### PR TITLE
Decouple SampleData from AncestorData

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -147,7 +147,9 @@ def run_infer(
     sample_data = tsinfer.SampleData.from_tree_sequence(ts)
 
     if exact_ancestors:
-        ancestor_data = tsinfer.AncestorData(sample_data)
+        ancestor_data = tsinfer.AncestorData(
+            sample_data.sites_position, sample_data.sequence_length
+        )
         tsinfer.build_simulated_ancestors(sample_data, ancestor_data, ts)
         ancestor_data.finalise()
     else:
@@ -535,7 +537,9 @@ def ancestor_properties_worker(args):
     }
 
     if compute_exact:
-        exact_anc = tsinfer.AncestorData(sample_data)
+        exact_anc = tsinfer.AncestorData(
+            sample_data.sites_position, sample_data.sequence_length
+        )
         tsinfer.build_simulated_ancestors(sample_data, exact_anc, ts)
         exact_anc.finalise()
         # Show lengths as a fraction of the total.
@@ -819,7 +823,9 @@ def sim_true_and_inferred_ancestors(args):
     sample_data = generate_samples(ts, args.error)
 
     inferred_anc = tsinfer.generate_ancestors(sample_data, engine=args.engine)
-    true_anc = tsinfer.AncestorData(sample_data)
+    true_anc = tsinfer.AncestorData(
+        sample_data.sites_position, sample_data.sequence_length
+    )
     tsinfer.build_simulated_ancestors(sample_data, true_anc, ts)
     true_anc.finalise()
     return sample_data, true_anc, inferred_anc

--- a/tsinfer/eval_util.py
+++ b/tsinfer/eval_util.py
@@ -695,7 +695,9 @@ def run_perfect_inference(
         logger.info("Using provided tree sequence")
         ancestors_ts = make_ancestors_ts(ts, remove_leaves=True)
     else:
-        ancestor_data = formats.AncestorData(sample_data)
+        ancestor_data = formats.AncestorData(
+            sample_data.sites_position, sample_data.sequence_length
+        )
         build_simulated_ancestors(
             sample_data, ancestor_data, ts, time_chunking=time_chunking
         )

--- a/visualisation.py
+++ b/visualisation.py
@@ -431,7 +431,9 @@ def visualise(
     sample_data = tsinfer.SampleData.from_tree_sequence(ts)
 
     if perfect_ancestors:
-        ancestor_data = tsinfer.AncestorData(sample_data)
+        ancestor_data = tsinfer.AncestorData(
+            sample_data.sites_position, sample_data.sequence_length
+        )
         tsinfer.build_simulated_ancestors(
             sample_data, ancestor_data, ts, time_chunking=time_chunking
         )


### PR DESCRIPTION
I thought this best done as a separate PR from the sgkit ancestors work. 

This ended up a bit more invasive than I had hoped. It looks like `ancestor_data.sequence_length` is used in quite a few places - mostly for making tree sequence tables of the ancestors, so I've also passed that through too, thought it might be possible to use `max(position)`? The main changes are in `generate_ancestors` and `AncestorsGenerator` as the `AncestorData` can no longer be made ahead of time, and has to be made once the sites are known.