### PR TITLE
Error if sgkit sample data is unphased

### DIFF
--- a/requirements/CI-docs/requirements.txt
+++ b/requirements/CI-docs/requirements.txt
@@ -1,5 +1,6 @@
 cyvcf2==0.30.18
 daiquiri==3.0.1
+dask[array]==2022.01.0
 humanize==4.4.0
 jupyter-book==0.13.1
 lmdb==1.3.0

--- a/requirements/CI-tests-conda/requirements.txt
+++ b/requirements/CI-tests-conda/requirements.txt
@@ -1,7 +1,7 @@
 attrs==22.1.0
 colorama==0.4.6
 daiquiri==3.0.0
-h5py==3.7.0 
+h5py==3.7.0
 humanize==4.4.0
 lmdb==0.9.29
 msprime==1.2.0

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -8,6 +8,7 @@ six
 tqdm
 humanize
 daiquiri
+dask[array]
 msprime >= 1.0.0
 tskit >= 0.5.3
 zarr!=2.11.0, !=2.11.1, !=2.11.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ install_requires =
     lmdb
     sortedcontainers
     attrs>=19.2.0
+    dask[array]
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Fixes #772

This is doing unnecessary checks as not all sites may be used - but this is the simplest approach. If we think there are common use cases where used are only using a subset of sites and the rest are unphased, then could consider only checking used sites.
