### PR TITLE
Dask experiments

### DIFF
--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -1,0 +1,39 @@
+import logging
+
+import msprime
+
+import tsinfer
+
+logger = logging.getLogger(__name__)
+
+
+def test_dask_match_ancestors(tmpdir):
+    from dask.distributed import Client
+    from dask.distributed import LocalCluster
+
+    cluster = LocalCluster(processes=True, threads_per_worker=1, n_workers=8)
+    client = Client(cluster)  # noqa F841
+    ts = msprime.sim_ancestry(
+        100, recombination_rate=3e-5, sequence_length=1e6, random_seed=42
+    )
+    ts = msprime.sim_mutations(ts, rate=3e-5, random_seed=42)
+    sd = tsinfer.SampleData.from_tree_sequence(ts)
+    anc = tsinfer.generate_ancestors(sd, path=str(tmpdir / "anc"), num_threads=8)
+    anc_ts_dask = tsinfer.match_ancestors(
+        sd,
+        anc,
+        recombination_rate=2e-8,
+        precision=13,
+        path_compression=True,
+        num_threads=8,
+        use_dask=True,
+    )
+    anc_ts = tsinfer.match_ancestors(
+        sd,
+        anc,
+        recombination_rate=2e-8,
+        precision=13,
+        path_compression=True,
+        num_threads=8,
+    )
+    anc_ts.tables.assert_equals(anc_ts_dask.tables, ignore_provenance=True)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1379,7 +1379,7 @@ class TestResume:
         ancestor_ts1 = tsinfer.match_ancestors(
             sample_data, ancestor_data, resume_lmdb_file=lmdb_file
         )
-        assert self.count_keys(lmdb_file) == 5
+        assert self.count_keys(lmdb_file) == 4
         ancestor_ts2 = tsinfer.match_ancestors(
             sample_data, ancestor_data, resume_lmdb_file=lmdb_file
         )
@@ -1409,7 +1409,7 @@ class TestResume:
             sample_data, ancestor_data, resume_lmdb_file=lmdb_file
         )
         time1 = time.time() - t
-        assert self.count_keys(lmdb_file) >= 104
+        assert self.count_keys(lmdb_file) >= 103
         t = time.time()
         ancestor_ts2 = tsinfer.match_ancestors(
             sample_data, ancestor_data, resume_lmdb_file=lmdb_file

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -2322,7 +2322,7 @@ class SgkitSampleData(SampleData):
     def finalised(self):
         return True
 
-    @property
+    @functools.cached_property
     def sequence_length(self):
         try:
             return self.data.attrs["sequence_length"]
@@ -2333,7 +2333,7 @@ class SgkitSampleData(SampleData):
     def num_sites(self):
         return self._num_sites
 
-    @property
+    @functools.cached_property
     def sites_metadata_schema(self):
         try:
             return tskit.metadata.parse_metadata_schema(
@@ -2342,7 +2342,7 @@ class SgkitSampleData(SampleData):
         except KeyError:
             return tskit.MetadataSchema.permissive_json().schema
 
-    @property
+    @functools.cached_property
     def sites_metadata(self):
         schema = tskit.MetadataSchema(self.sites_metadata_schema)
         try:
@@ -2353,22 +2353,22 @@ class SgkitSampleData(SampleData):
         except KeyError:
             return [{} for _ in range(self.num_sites)]
 
-    @property
+    @functools.cached_property
     def sites_time(self):
         try:
             return self.data["sites_time"][:][self.sites_mask]
         except KeyError:
             return np.full(self.num_sites, tskit.UNKNOWN_TIME)
 
-    @property
+    @functools.cached_property
     def sites_position(self):
         return self.data["variant_position"][:][self.sites_mask]
 
-    @property
+    @functools.cached_property
     def sites_alleles(self):
         return self.data["variant_allele"][:][self.sites_mask]
 
-    @property
+    @functools.cached_property
     def sites_mask(self):
         try:
             if (
@@ -2390,7 +2390,7 @@ class SgkitSampleData(SampleData):
         except KeyError:
             return np.full(self.data["variant_position"].shape, True, dtype=bool)
 
-    @property
+    @functools.cached_property
     def sites_ancestral_allele(self):
         try:
             string_allele = self.data["variant_ancestral_allele"][:][self.sites_mask]
@@ -2399,10 +2399,11 @@ class SgkitSampleData(SampleData):
             # ancestral allele was always the zeroth element in the alleles list
             warnings.warn("No ancestral allele information found, using 0th allele")
             return np.zeros(self.num_sites, dtype=np.int8)
+        sites_alleles = self.sites_alleles
         try:
             return np.array(
                 [
-                    np.where(allele == self.sites_alleles[i])[0][0]
+                    np.where(allele == sites_alleles[i])[0][0]
                     for i, allele in enumerate(string_allele)
                 ]
             )
@@ -2411,7 +2412,7 @@ class SgkitSampleData(SampleData):
                 "An ancestral allele is not present in the variant's alleles"
             )
 
-    @property
+    @functools.cached_property
     def sites_genotypes(self):
         gt = self.data["call_genotype"]
         # This method is only used for test/debug so we retrieve and


### PR DESCRIPTION
Sample matching using dask.
The overhead for using the default dask client with threads in the current process is very small ~2-3%, as the TSB doesn't need to be serialised.
For multi-process workers I get a ~30% longer runtime, this is worst case as I have only 1000 samples and 10000 sites.
The extra cost is mostly fixed setup cost, this is worth it for flexible multi-node worker clusters though I think. 

This needs some tidying up before merging, and reworking the testing, (the test_dask.py was more of a playground than actual testing).