### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,7 @@ Binary packages
 The most reliable way to install ``tsinfer`` is to install the binary conda package:
 e.g.::
 
-    $ conda -c conda-forge install tsinfer
+    $ conda install tsinfer -c conda-forge
 
 you can then ``import tsinfer`` in python or use the ``tsinfer`` executable directly::
 


### PR DESCRIPTION
This conda install command in the tsinfer docs does not work because `conda` must be followed by a command. See error from bash terminal call of `conda -c conda-forge install tsinfer`:

```bash
CommandNotFoundError: No command 'conda conda-forge'.
```