### PR TITLE
Add more tests to ancestral_allele fetching

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
         id: venv-cache
         with:
           path: venv
-          key: docs-venv-v2-${{ hashFiles('requirements/CI-docs/requirements.txt') }}
+          key: docs-venv-v3-${{ hashFiles('requirements/CI-docs/requirements.txt') }}
 
       - name: Create venv and install deps (one by one to avoid conflict errors)
         if: steps.venv-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
As part of looking into why adding an ancestral allele makes ancestor generation very slow I'm adding more paranoid testing to the ancestral allele fetcher. Looks like it is working, but good to leave the tests in anyway.