### PR TITLE
Dask sample matching

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
         id: venv-cache
         with:
           path: venv
-          key: docs-venv-v3-${{ hashFiles('requirements/CI-docs/requirements.txt') }}
+          key: docs-venv-v5-${{ hashFiles('requirements/CI-docs/requirements.txt') }}
 
       - name: Create venv and install deps (one by one to avoid conflict errors)
         if: steps.venv-cache.outputs.cache-hit != 'true'

--- a/tests/test_dask.py
+++ b/tests/test_dask.py
@@ -1,6 +1,9 @@
 import logging
+import sys
 
 import msprime
+import pytest
+from test_sgkit import make_ts_and_zarr
 
 import tsinfer
 
@@ -11,21 +14,21 @@ def test_dask_match_ancestors(tmpdir):
     from dask.distributed import Client
     from dask.distributed import LocalCluster
 
-    cluster = LocalCluster(processes=True, threads_per_worker=1, n_workers=8)
+    cluster = LocalCluster(processes=True, threads_per_worker=1, n_workers=2)
     client = Client(cluster)  # noqa F841
     ts = msprime.sim_ancestry(
         100, recombination_rate=3e-5, sequence_length=1e6, random_seed=42
     )
     ts = msprime.sim_mutations(ts, rate=3e-5, random_seed=42)
     sd = tsinfer.SampleData.from_tree_sequence(ts)
-    anc = tsinfer.generate_ancestors(sd, path=str(tmpdir / "anc"), num_threads=8)
+    anc = tsinfer.generate_ancestors(sd, path=str(tmpdir / "anc"), num_threads=2)
     anc_ts_dask = tsinfer.match_ancestors(
         sd,
         anc,
         recombination_rate=2e-8,
         precision=13,
         path_compression=True,
-        num_threads=8,
+        num_threads=2,
         use_dask=True,
     )
     anc_ts = tsinfer.match_ancestors(
@@ -34,6 +37,54 @@ def test_dask_match_ancestors(tmpdir):
         recombination_rate=2e-8,
         precision=13,
         path_compression=True,
-        num_threads=8,
+        num_threads=2,
     )
     anc_ts.tables.assert_equals(anc_ts_dask.tables, ignore_provenance=True)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="No cyvcf2 on Windows")
+def test_dask_match_samples(tmp_path):
+    from dask.distributed import Client
+    from dask.distributed import LocalCluster
+
+    cluster = LocalCluster(processes=False, threads_per_worker=1, n_workers=2)
+    client = Client(cluster)  # noqa F841
+    ts, zarr_path = make_ts_and_zarr(tmp_path)
+    sd = tsinfer.SgkitSampleData(zarr_path)
+    anc = tsinfer.generate_ancestors(sd, path=str(tmp_path / "anc"), num_threads=2)
+    anc_ts_dask = tsinfer.match_ancestors(
+        sd,
+        anc,
+        recombination_rate=2e-8,
+        precision=13,
+        path_compression=True,
+        num_threads=1,
+        use_dask=True,
+    )
+    anc_ts = tsinfer.match_ancestors(
+        sd,
+        anc,
+        recombination_rate=2e-8,
+        precision=13,
+        path_compression=True,
+        num_threads=1,
+    )
+    anc_ts.tables.assert_equals(anc_ts_dask.tables, ignore_provenance=True)
+    inf_ts_dask = tsinfer.match_samples(
+        sd,
+        anc_ts,
+        recombination_rate=2e-8,
+        precision=13,
+        path_compression=True,
+        num_threads=1,
+        use_dask=True,
+    )
+    inf_ts = tsinfer.match_samples(
+        sd,
+        anc_ts,
+        recombination_rate=2e-8,
+        precision=13,
+        path_compression=True,
+        num_threads=1,
+    )
+    inf_ts.tables.assert_equals(inf_ts_dask.tables, ignore_provenance=True)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1384,15 +1384,14 @@ class TestResume:
             sample_data, ancestor_data, resume_lmdb_file=lmdb_file
         )
         ancestor_ts1.tables.assert_equals(ancestor_ts2.tables, ignore_provenance=True)
-        # TODO No caching on samples for now
-        # final_ts1 = tsinfer.match_samples(
-        #     sample_data, ancestor_ts1, resume_lmdb_file=lmdb_file
-        # )
-        # assert self.count_keys(lmdb_file) == 4
-        # final_ts2 = tsinfer.match_samples(
-        #     sample_data, ancestor_ts1, resume_lmdb_file=lmdb_file
-        # )
-        # final_ts1.tables.assert_equals(final_ts2.tables, ignore_provenance=True)
+        final_ts1 = tsinfer.match_samples(
+            sample_data, ancestor_ts1, resume_lmdb_file=lmdb_file
+        )
+        assert self.count_keys(lmdb_file) == 5
+        final_ts2 = tsinfer.match_samples(
+            sample_data, ancestor_ts1, resume_lmdb_file=lmdb_file
+        )
+        final_ts1.tables.assert_equals(final_ts2.tables, ignore_provenance=True)
 
     def test_cache_used_by_timing(self, tmpdir):
         lmdb_file = str(tmpdir / "LMDB")
@@ -1418,20 +1417,19 @@ class TestResume:
         time2 = time.time() - t
         assert time2 < time1 / 2
 
-        # TODO No caching on samples for now
-        # t = time.time()
-        # final_ts1 = tsinfer.match_samples(
-        #     sample_data, ancestor_ts1, resume_lmdb_file=lmdb_file
-        # )
-        # time1 = time.time() - t
-        # assert self.count_keys(lmdb_file) == 1201
-        # t = time.time()
-        # final_ts2 = tsinfer.match_samples(
-        #     sample_data, ancestor_ts1, resume_lmdb_file=lmdb_file
-        # )
-        # time2 = time.time() - t
-        # assert time2 < time1 / 1.5
-        # final_ts1.tables.assert_equals(final_ts2.tables, ignore_provenance=True)
+        t = time.time()
+        final_ts1 = tsinfer.match_samples(
+            sample_data, ancestor_ts1, resume_lmdb_file=lmdb_file
+        )
+        time1 = time.time() - t
+        assert self.count_keys(lmdb_file) == 104
+        t = time.time()
+        final_ts2 = tsinfer.match_samples(
+            sample_data, ancestor_ts1, resume_lmdb_file=lmdb_file
+        )
+        time2 = time.time() - t
+        assert time2 < time1 / 1.25
+        final_ts1.tables.assert_equals(final_ts2.tables, ignore_provenance=True)
 
 
 class TestAncestorGeneratorsEquivalant:

--- a/tests/test_sgkit.py
+++ b/tests/test_sgkit.py
@@ -415,28 +415,6 @@ class TestSgkitMask:
         #     site.metadata for site in inf_ts.sites()
         # ]
 
-    def test_sgkit_variant_bad_mask(self, tmp_path):
-        ts, zarr_path = make_ts_and_zarr(tmp_path)
-        ds = sgkit.load_dataset(zarr_path)
-        sites_mask = np.arange(ds.sizes["variants"], dtype=int)
-        add_array_to_dataset("variant_mask", sites_mask, zarr_path)
-        with pytest.raises(
-            ValueError,
-            match="The variant_mask array contains values " "other than 0 or 1",
-        ):
-            tsinfer.SgkitSampleData(zarr_path)
-
-    def test_sgkit_variant_bad_mask_negative(self, tmp_path):
-        ts, zarr_path = make_ts_and_zarr(tmp_path)
-        ds = sgkit.load_dataset(zarr_path)
-        sites_mask = np.arange(0, -ds.sizes["variants"], -1, dtype=int)
-        add_array_to_dataset("variant_mask", sites_mask, zarr_path)
-        with pytest.raises(
-            ValueError,
-            match="The variant_mask array contains values " "other than 0 or 1",
-        ):
-            tsinfer.SgkitSampleData(zarr_path)
-
     def test_sgkit_variant_bad_mask_length(self, tmp_path):
         ts, zarr_path = make_ts_and_zarr(tmp_path)
         ds = sgkit.load_dataset(zarr_path)


### PR DESCRIPTION
Stacked on #849 
There are some challenges here with reading the sample data off disk in a performant manner. Initially, each sample was an individual `dask` task, but this means that each task must read a "sample chunk width" amount of data off disk. This was changed to combine 10 contiguous matching tasks into one `dask` task.