### PR TITLE
Make tqdm work nicely in notebooks

### DIFF
--- a/tsinfer/progress.py
+++ b/tsinfer/progress.py
@@ -19,7 +19,7 @@
 """
 A progress monitor class for tsinfer
 """
-import tqdm
+from tqdm.auto import tqdm
 
 
 class ProgressMonitor:
@@ -83,7 +83,7 @@ class ProgressMonitor:
             "{desc}{percentage:3.0f}%|{bar}"
             "| {n_fmt}/{total_fmt} [{elapsed}, {rate_fmt}{postfix}]"
         )
-        self.current_instance = tqdm.tqdm(
+        self.current_instance = tqdm(
             desc=desc,
             total=total,
             disable=not self.enabled,


### PR DESCRIPTION
For testing, it's handy to run tsinfer in notebooks, but the tqdm taskbar often pipes lots of output to screen. The attached minor change is basically what we do in tsdate. Any reason not to do this in tsinfer?