### PR TITLE
Specify standard python (not python3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CFLAGS=-std=c99 -g -O3 -march=native -funroll-loops -ffast-math \
 all: _tsinfer.cpython-34m.so 
 
 _tsinfer.cpython-34m.so: _tsinfermodule.c 
-	CC="${CC}" CFLAGS="${CFLAGS}" python3 setup.py build_ext --inplace
+	CC="${CC}" CFLAGS="${CFLAGS}" python setup.py build_ext --inplace
 
 ctags:
 	ctags lib/*.c lib/*.h tsinfer/*.py


### PR DESCRIPTION
My mamba installation doesn't create a "python3" symlink any more, so I have to hack the makefile whenever I want to compile tsinfer. I think we can assume that any call to "python" invokes a version 3 of python by now.