### PR TITLE
Numpy2 changes

### DIFF
--- a/tsinfer/algorithm.py
+++ b/tsinfer/algorithm.py
@@ -111,7 +111,8 @@ class AncestorBuilder:
                 g[j] = int((byte & mask) != 0)
         else:
             for j, u in enumerate(samples):
-                g[j] = self.genotype_store[start + u]
+                # NB missing data (-1) is stored as 255 in the genotype_store
+                g[j] = self.genotype_store[start + u].astype(np.int8)
         gp = self.get_site_genotypes(site_id)
         np.testing.assert_array_equal(gp[samples], g)
         return g
@@ -129,6 +130,8 @@ class AncestorBuilder:
         if self.genotype_encoding == constants.GenotypeEncoding.ONE_BIT:
             assert np.all(genotypes >= 0) and np.all(genotypes <= 1)
             genotypes = np.packbits(genotypes, bitorder="little")
+        else:
+            assert np.all(genotypes <= 127)
         start = site_id * self.encoded_genotypes_size
         stop = start + self.encoded_genotypes_size
         self.genotype_store[start:stop] = genotypes

--- a/tsinfer/constants.py
+++ b/tsinfer/constants.py
@@ -21,6 +21,8 @@ Collection of constants used in tsinfer. We also make use of constants defined i
 """
 import enum
 
+import numpy as np
+
 C_ENGINE = "C"
 PY_ENGINE = "P"
 
@@ -28,16 +30,16 @@ PY_ENGINE = "P"
 # TODO Change these to use the enum.IntFlag class
 
 # Bit 16 is set in node flags when they have been created by path compression.
-NODE_IS_PC_ANCESTOR = 1 << 16
+NODE_IS_PC_ANCESTOR = np.uint32(1 << 16)
 # Bit 17 is set in node flags when they have been created by shared recombination
 # breakpoint
-NODE_IS_SRB_ANCESTOR = 1 << 17
+NODE_IS_SRB_ANCESTOR = np.uint32(1 << 17)
 # Bit 18 is set in node flags when they are samples inserted to augment existing
 # ancestors.
-NODE_IS_SAMPLE_ANCESTOR = 1 << 18
+NODE_IS_SAMPLE_ANCESTOR = np.uint32(1 << 18)
 # Bit 20 is set in node flags when they are samples not at time zero in the sampledata
 # file
-NODE_IS_HISTORICAL_SAMPLE = 1 << 20
+NODE_IS_HISTORICAL_SAMPLE = np.uint32(1 << 20)
 
 # What type of inference have we done at a site?
 INFERENCE_NONE = "none"

--- a/tsinfer/eval_util.py
+++ b/tsinfer/eval_util.py
@@ -542,7 +542,9 @@ def extract_ancestors(samples, ts):
     index = tables.nodes.flags == tskit.NODE_IS_SAMPLE
     flags[index] = tskit.NODE_IS_SAMPLE
     index = tables.nodes.flags != tskit.NODE_IS_SAMPLE
-    flags[index] = np.bitwise_and(tables.nodes.flags[index], ~tskit.NODE_IS_SAMPLE)
+    flags[index] = np.bitwise_and(
+        tables.nodes.flags[index], ~flags.dtype.type(tskit.NODE_IS_SAMPLE)
+    )
 
     tables.nodes.set_columns(
         flags=flags,

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -1271,7 +1271,7 @@ class SampleData(DataContainer):
     @sites_time.setter
     def sites_time(self, value):
         self._check_edit_mode()
-        self.data["sites/time"][:] = np.array(value, dtype=np.float64, copy=False)
+        self.data["sites/time"][:] = np.asarray(value, dtype=np.float64)
 
     @property
     def sites_alleles(self):

--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -148,7 +148,7 @@ def count_pc_ancestors(flags):
     Returns the number of values in the specified array which have the
     NODE_IS_PC_ANCESTOR set.
     """
-    flags = np.array(flags, dtype=np.uint32, copy=False)
+    flags = np.asarray(flags, dtype=np.uint32)
     return np.sum(is_pc_ancestor(flags))
 
 
@@ -157,7 +157,7 @@ def count_srb_ancestors(flags):
     Returns the number of values in the specified array which have the
     NODE_IS_SRB_ANCESTOR set.
     """
-    flags = np.array(flags, dtype=np.uint32, copy=False)
+    flags = np.asarray(flags, dtype=np.uint32)
     return np.sum(np.bitwise_and(flags, constants.NODE_IS_SRB_ANCESTOR) != 0)
 
 


### PR DESCRIPTION
With this, almost all tests pass under numpy2, except for one of the 8-bit conversion routines. Do you know what's going on here @benjeffery ?

```python
    def get_site_genotypes_subset(self, site_id, samples):
        start = site_id * self.encoded_genotypes_size
        g = np.zeros(len(samples), dtype=np.int8)
        if self.genotype_encoding == constants.GenotypeEncoding.ONE_BIT:
            for j, u in enumerate(samples):
                byte_index = u // 8
                bit_index = u % 8
                byte = self.genotype_store[start + byte_index]
                mask = 1 << bit_index
                g[j] = int((byte & mask) != 0)
        else:
            for j, u in enumerate(samples):
>               g[j] = self.genotype_store[start + u]
>> E               OverflowError: Python integer 255 out of bounds for int8

```