### PR TITLE
Remove mention of sgkit

### DIFF
--- a/tests/test_variantdata.py
+++ b/tests/test_variantdata.py
@@ -142,7 +142,7 @@ def test_sgkit_dataset_accessors(tmp_path):
     )
     ds = sgkit.load_dataset(zarr_path)
 
-    assert samples.format_name == "tsinfer-sgkit-sample-data"
+    assert samples.format_name == "tsinfer-variant-data"
     assert samples.format_version == (0, 1)
     assert samples.finalised
     assert samples.sequence_length == ts.sequence_length + 1337

--- a/tsinfer/formats.py
+++ b/tsinfer/formats.py
@@ -2294,7 +2294,7 @@ class SampleData(DataContainer):
 
 class VariantData(SampleData):
 
-    FORMAT_NAME = "tsinfer-sgkit-sample-data"
+    FORMAT_NAME = "tsinfer-variant-data"
     FORMAT_VERSION = (0, 1)
 
     def __init__(
@@ -2354,7 +2354,7 @@ class VariantData(SampleData):
             if "call_genotype_phased" not in self.data:
                 raise ValueError(
                     "The call_genotype_phased array is missing from the"
-                    " sgkit dataset, indicating that all the genotypes are"
+                    " zarr dataset, indicating that all the genotypes are"
                     " unphased"
                 )
         if np.any(np.diff(self.sites_position) <= 0):


### PR DESCRIPTION
Note that this changes the FORMAT_NAME, so is no longer backward-compatible with previous tsinfer data files. But I think that's fine, because we only save the .vcz file normally anyway.

There are still references to sgkit in the test suite, but I think that's fine too.