### PR TITLE
Record more tsinfer parameters in provenance

### DIFF
--- a/tsinfer/inference.py
+++ b/tsinfer/inference.py
@@ -380,6 +380,11 @@ def infer(
         record = provenance.get_provenance_dict(
             command="infer",
             mismatch_ratio=mismatch_ratio,
+            path_compression=path_compression,
+            precision=precision,
+            simplify=simplify,
+            post_process=post_process,
+            # TODO: maybe record recombination rate (which could be a RateMap)
         )
         tables.provenances.add_row(record=json.dumps(record))
         inferred_ts = tables.tree_sequence()
@@ -577,6 +582,9 @@ def match_ancestors(
         record = provenance.get_provenance_dict(
             command="match_ancestors",
             mismatch_ratio=mismatch_ratio,
+            path_compression=path_compression,
+            precision=precision,
+            # TODO: maybe record recombination rate (which could be a RateMap)
         )
         tables.provenances.add_row(record=json.dumps(record))
     ts = tables.tree_sequence()
@@ -810,6 +818,8 @@ def match_ancestors_batch_finalise(work_dir):
         record = provenance.get_provenance_dict(
             command="match_ancestors",
             mismatch_ratio=metadata["mismatch_ratio"],
+            path_compression=metadata["path_compression"],
+            precision=metadata["precision"],
         )
         tables.provenances.add_row(record=json.dumps(record))
     ts = tables.tree_sequence()
@@ -901,6 +911,8 @@ def augment_ancestors(
         record = provenance.get_provenance_dict(
             command="augment_ancestors",
             mismatch_ratio=mismatch_ratio,
+            path_compression=path_compression,
+            precision=precision,
         )
         tables.provenances.add_row(record=json.dumps(record))
         ts = tables.tree_sequence()
@@ -1257,6 +1269,11 @@ def match_samples(
         record = provenance.get_provenance_dict(
             command="match_samples",
             mismatch_ratio=mismatch_ratio,
+            path_compression=path_compression,
+            precision=precision,
+            simplify=simplify,
+            post_process=post_process,
+            # TODO: maybe record recombination rate (which could be a RateMap)
         )
         tables.provenances.add_row(record=json.dumps(record))
         ts = tables.tree_sequence()

--- a/tsinfer/provenance.py
+++ b/tsinfer/provenance.py
@@ -75,6 +75,11 @@ def get_provenance_dict(command=None, **kwargs):
         raise ValueError("Command must be provided")
     parameters = dict(kwargs)
     parameters["command"] = command
+    if "simplify" in parameters:
+        if parameters["simplify"] is None:
+            del parameters["simplify"]  # simplify is deprecated version of post_process
+        else:
+            del parameters["post_process"]
     document = {
         "schema_version": "1.0.0",
         "software": {"name": "tsinfer", "version": __version__},


### PR DESCRIPTION
These are useful when coming to inspect how the tree sequence was inferred (Savita would have found it useful recently).